### PR TITLE
Feature-57: Backfill `partypublic` values that are currently null

### DIFF
--- a/src/database/migrations/V1.13__backfill_party_null_values.sql
+++ b/src/database/migrations/V1.13__backfill_party_null_values.sql
@@ -1,0 +1,12 @@
+----------------------------------------------------------------------------
+-- Update party table for specific party_ids to be True
+----------------------------------------------------------------------------
+UPDATE Party
+SET partypublic = TRUE
+WHERE party_id IN (458, 456, 474, 413, 291, 347);
+----------------------------------------------------------------------------
+-- Everything that is still null thereafter is False
+----------------------------------------------------------------------------
+UPDATE Party
+SET partypublic = FALSE
+WHERE partypublic IS NULL;


### PR DESCRIPTION
**Summary of Changes:**
- Added a new migration file that finds the specific `party_id`s in the issue and sets their `partypublic` value to be `TRUE`, and any remaining `partypublic` value that is `NULL` is set to `FALSE`