### PR TITLE
Feature 78 specify image version for vegbank docker image

### DIFF
--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -14,7 +14,7 @@ image:
   pullPolicy: IfNotPresent
   ## Overrides the image tag whose default is the chart appVersion.
   ## @param image.tag - The tag of the image to use.
-  tag: "vegbank:0.2.0"
+  tag: "vegbank:0.0.2"
 
 ## @param imagePullSecrets
 imagePullSecrets: []


### PR DESCRIPTION
I'm adding the specific version 0.0.2, which is our current alpha version. This will allow me to work on version 0.0.3, which will have our first round of upload methods. 