### PR TITLE
Feature 96 create secret for db authentication

### DIFF
--- a/helm/Chart.yaml
+++ b/helm/Chart.yaml
@@ -24,7 +24,7 @@ version: "0.0.1"
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "0.0.2"
+appVersion: "0.0.3"
 
 dependencies: 
 - name: postgresql

--- a/helm/admin/secret.yaml
+++ b/helm/admin/secret.yaml
@@ -1,0 +1,23 @@
+######################################################################################
+#     D O   N O T   C H E C K   C R E D E N T I A L S   I N T O   G I T H U B ! ! !
+######################################################################################
+#
+apiVersion: v1
+kind: Secret
+metadata:
+  name: vegbankdbcreds 
+type: Opaque 
+## @param stringData write-only, non-binary secret data (eg credentials) in string form.
+##
+## # # #    NEVER CHECK SECRETS INTO GITHUB!   # # #
+##
+stringData:
+  ## @param 'DB_PASSWORD'
+  ## the Postgres database password for the vegbank user
+  ##
+  ## IMPORTANT NOTE: Once the chart is deployed, it is not possible to change the application's
+  ## access credentials, such as usernames or passwords, using Helm. To change these application
+  ## credentials after deployment, delete any persistent volumes (PVs) used by the chart and
+  ## re-deploy it, or use the application's built-in administrative tools if available.
+  ##
+  DB_PASSWORD: "YOUR-PASSWORD-HERE"

--- a/helm/admin/secret.yaml
+++ b/helm/admin/secret.yaml
@@ -6,13 +6,16 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: vegbankdbcreds 
-type: Opaque 
+type: kubernetes.io/basic-auth 
 ## @param stringData write-only, non-binary secret data (eg credentials) in string form.
 ##
 ## # # #    NEVER CHECK SECRETS INTO GITHUB!   # # #
 ##
 stringData:
-  ## @param 'DB_PASSWORD'
+  ## @param 'username'
+  ## The username for the vegbank postgres user. This is in the secret for later use by CNPG even though it doesn't necessarily need to be secret. 
+  username: vegbank
+  ## @param 'password'
   ## the Postgres database password for the vegbank user
   ##
   ## IMPORTANT NOTE: Once the chart is deployed, it is not possible to change the application's
@@ -20,4 +23,4 @@ stringData:
   ## credentials after deployment, delete any persistent volumes (PVs) used by the chart and
   ## re-deploy it, or use the application's built-in administrative tools if available.
   ##
-  DB_PASSWORD: "YOUR-PASSWORD-HERE"
+  password: "YOUR-PASSWORD-HERE"

--- a/helm/templates/deployment.yaml
+++ b/helm/templates/deployment.yaml
@@ -50,6 +50,20 @@ spec:
           volumeMounts:
             {{- toYaml . | nindent 12 }}
           {{- end }}
+          env:
+            - name: db_pass
+              valueFrom:
+                secretKeyRef:
+                  name: vegbankdbcreds
+                  key: DB_PASSWORD
+            - name: db_name
+              value: {{ .Values.database.db_name | quote }}
+            - name: db_user
+              value: {{ .Values.database.db_user | quote }}
+            - name: db_host
+              value: {{ .Values.database.db_host | quote }}
+            - name: db_port
+              value: {{ .Values.database.db_port | quote }}
       {{- with .Values.volumes }}
       volumes:
         {{- toYaml . | nindent 8 }}

--- a/helm/templates/deployment.yaml
+++ b/helm/templates/deployment.yaml
@@ -51,19 +51,22 @@ spec:
             {{- toYaml . | nindent 12 }}
           {{- end }}
           env:
-            - name: db_pass
+            - name: VB_DB_PASS
               valueFrom:
                 secretKeyRef:
                   name: vegbankdbcreds
-                  key: DB_PASSWORD
-            - name: db_name
-              value: {{ .Values.database.db_name | quote }}
-            - name: db_user
-              value: {{ .Values.database.db_user | quote }}
-            - name: db_host
-              value: {{ .Values.database.db_host | quote }}
-            - name: db_port
-              value: {{ .Values.database.db_port | quote }}
+                  key: password
+            - name: VB_DB_USER
+              valueFrom:
+                secretKeyRef:
+                  name: vegbankdbcreds
+                  key: username
+            - name: VB_DB_NAME
+              value: {{ .Values.database.name | quote }}
+            - name: VB_DB_HOST
+              value: {{ .Values.database.host | quote }}
+            - name: VB_DB_PORT
+              value: {{ .Values.database.port | quote }}
       {{- with .Values.volumes }}
       volumes:
         {{- toYaml . | nindent 8 }}

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -9,8 +9,6 @@ replicaCount: 1
 database:
   ## @param db_name - The name of the database on the postgres pod to be used by VegBank.
   name: vegbank
-  ## @param db_user - The user name for the database to be used by VegBank.
-  user: vegbank
   ## @param db_host - The host name of the database to be used by VegBank. Currently defined by bitnami, but will change. 
   host: vegbankdb-postgresql
   ## @param db_port - The port to connect to on the database pod. 

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -4,6 +4,19 @@
 ## @param replicaCount  The number of API pods to be created when the chart is installed. 
 replicaCount: 1
 
+## @section Database
+## configuration for the PostgreSQL database used by VegBank.
+database:
+  ## @param db_name - The name of the database on the postgres pod to be used by VegBank.
+  db_name: vegbank
+  ## @param db_user - The user name for the database to be used by VegBank.
+  db_user: vegbank
+  ## @param db_host - The host name of the database to be used by VegBank. Currently defined by bitnami, but will change. 
+  db_host: vegbankdb-postgresql
+  ## @param db_port - The port to connect to on the database pod. 
+  db_port: 5432
+
+
 ## @section Image 
 ## configuration for the docker image of the Flask API. 
 image:
@@ -14,7 +27,7 @@ image:
   pullPolicy: IfNotPresent
   ## Overrides the image tag whose default is the chart appVersion.
   ## @param image.tag - The tag of the image to use.
-  tag: 0.0.2
+  tag: 0.0.3
 
 ## @param imagePullSecrets
 imagePullSecrets: []
@@ -67,7 +80,7 @@ service:
 ## automatically pulls the default named service for the pod via release name. The section establishing that service is above. 
 ingress: 
   ## @param ingress.enabled - Should the ingress be enabled?
-  enabled: true
+  enabled: false
   ## @param ingress.className - The class of the ingress controller to use.
   className: nginx
   ## @section ingress.annotations - Annotations to add to the ingress resource.

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -8,13 +8,13 @@ replicaCount: 1
 ## configuration for the PostgreSQL database used by VegBank.
 database:
   ## @param db_name - The name of the database on the postgres pod to be used by VegBank.
-  db_name: vegbank
+  name: vegbank
   ## @param db_user - The user name for the database to be used by VegBank.
-  db_user: vegbank
+  user: vegbank
   ## @param db_host - The host name of the database to be used by VegBank. Currently defined by bitnami, but will change. 
-  db_host: vegbankdb-postgresql
+  host: vegbankdb-postgresql
   ## @param db_port - The port to connect to on the database pod. 
-  db_port: 5432
+  port: 5432
 
 
 ## @section Image 
@@ -24,10 +24,7 @@ image:
   repository: ghcr.io/nceas/vegbank
   ## @param image.pullPolicy - How often should the image be pulled from the repository?
   ## Set to Always for local development, IfNotPresent for production. 
-  pullPolicy: IfNotPresent
-  ## Overrides the image tag whose default is the chart appVersion.
-  ## @param image.tag - The tag of the image to use.
-  tag: 0.0.3
+  pullPolicy: Always
 
 ## @param imagePullSecrets
 imagePullSecrets: []
@@ -80,7 +77,7 @@ service:
 ## automatically pulls the default named service for the pod via release name. The section establishing that service is above. 
 ingress: 
   ## @param ingress.enabled - Should the ingress be enabled?
-  enabled: true
+  enabled: false
   ## @param ingress.className - The class of the ingress controller to use.
   className: nginx
   ## @section ingress.annotations - Annotations to add to the ingress resource.

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -24,7 +24,7 @@ image:
   repository: ghcr.io/nceas/vegbank
   ## @param image.pullPolicy - How often should the image be pulled from the repository?
   ## Set to Always for local development, IfNotPresent for production. 
-  pullPolicy: Always
+  pullPolicy: IfNotPresent
 
 ## @param imagePullSecrets
 imagePullSecrets: []
@@ -77,7 +77,7 @@ service:
 ## automatically pulls the default named service for the pod via release name. The section establishing that service is above. 
 ingress: 
   ## @param ingress.enabled - Should the ingress be enabled?
-  enabled: false
+  enabled: true
   ## @param ingress.className - The class of the ingress controller to use.
   className: nginx
   ## @section ingress.annotations - Annotations to add to the ingress resource.

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -80,7 +80,7 @@ service:
 ## automatically pulls the default named service for the pod via release name. The section establishing that service is above. 
 ingress: 
   ## @param ingress.enabled - Should the ingress be enabled?
-  enabled: false
+  enabled: true
   ## @param ingress.className - The class of the ingress controller to use.
   className: nginx
   ## @section ingress.annotations - Annotations to add to the ingress resource.

--- a/vegbank/config_template.py
+++ b/vegbank/config_template.py
@@ -1,7 +1,0 @@
-params = {
-        'dbname' : 'DB_NAME',
-        'user' : 'DB_USER',
-        'password' : 'DB_PASS', #TODO: set up secret for db password. This is not the real one. 
-        'host' : 'CHART_NAME-postgresql', #service name via bitnami postgres
-        'port' : '5432'
-    }

--- a/vegbank/vegbankapi.py
+++ b/vegbank/vegbankapi.py
@@ -16,11 +16,11 @@ app = Flask(__name__)
 app.config['UPLOAD_FOLDER'] = UPLOAD_FOLDER
 
 params = {}
-params['dbname'] = os.getenv('db_name')
-params['user'] = os.getenv('db_user')
-params['host'] = os.getenv('db_host')
-params['port'] = os.getenv('db_port')
-params['password'] = os.getenv('db_pass')
+params['dbname'] = os.getenv('VB_DB_NAME')
+params['user'] = os.getenv('VB_DB_USER')
+params['host'] = os.getenv('VB_DB_HOST')
+params['port'] = os.getenv('VB_DB_PORT')
+params['password'] = os.getenv('VB_DB_PASS')
 
 default_detail = "full"
 default_limit = 1000

--- a/vegbank/vegbankapi.py
+++ b/vegbank/vegbankapi.py
@@ -6,7 +6,7 @@ import pandas as pd
 import pyarrow 
 import io
 import time
-import config
+import os
 
 UPLOAD_FOLDER = '/vegbank2/uploads' #For future use with uploading parquet files if necessary
 ALLOWED_EXTENSIONS = 'parquet'
@@ -15,7 +15,12 @@ QUERIES_FOLDER = 'queries/'
 app = Flask(__name__)
 app.config['UPLOAD_FOLDER'] = UPLOAD_FOLDER
 
-params = config.params
+params = {}
+params['dbname'] = os.getenv('db_name')
+params['user'] = os.getenv('db_user')
+params['host'] = os.getenv('db_host')
+params['port'] = os.getenv('db_port')
+params['password'] = os.getenv('db_pass')
 
 default_detail = "full"
 default_limit = 1000


### PR DESCRIPTION
This PR changes our authentication method between the flask pod and the postgres pod to a secret/environment variable setup in line with what we will use in production. The details (username, password, service name) will change when we got to CNPG, but the format will remain the same. The components are as follows:

secret.yaml: This file contains the database password, and is placed in the helm/admin folder so that it won't get automatically deployed along with the chart. The intention here is to avoid the real plain text password being bundled along with the helm chart if it were ever packaged together as a zip file later on. A user installing the chart should copy the secret.yaml file to a location outside the chart, add the password, and then apply the secret to their namespace. 

values.yaml: This file contains the other non password credentials including username, service host name, port, and database name. When we go to CNPG, the information here will need to be updated accordingly. 

deployment.yaml: The update here pulls the credentials from the values file and the secret into the environment variables of the container so flask can use them. 

vegbankapi.py: I have updated the params dictionary here to pull its values from the environment variables rather than from a config file, and I deleted the template for the config file, config_template.py since it will no longer be used. These details can remain the same after we go to CNPG as long as we don't change the environment variable names in deployment.yaml. 