### PR TITLE
Feature-103: Add New `identifiers` Table

### DIFF
--- a/helm/db/migrations/V1.7__create_identifiers_table.sql
+++ b/helm/db/migrations/V1.7__create_identifiers_table.sql
@@ -10,3 +10,52 @@ CREATE TABLE identifiers (
   identifier_value TEXT NOT NULL, -- e.g., "vb.ob.1234.abcd", "10.1234/abcd", "0000-0002-1825-0097"
   UNIQUE (identifier_type, identifier_value) -- Prevent duplicate mappings
 );
+
+-- Create a mapping table to iterate over for the vb_code procedure
+CREATE TABLE identifiers_source_map (
+  source_table TEXT NOT NULL,   -- table name
+  table_code   TEXT NOT NULL,   -- short code for the table
+  pk_column    TEXT NOT NULL,   -- primary key column of the source table
+  id_type      TEXT NOT NULL    -- identifier type (e.g., AccessionCode)
+);
+
+-- Create identifiers source map for procedures to iterate over
+INSERT INTO identifiers_source_map (source_table, table_code, pk_column, id_type) VALUES
+  ('aux_role', 'ar', 'role_id', 'accession_code'),
+  ('commClass', 'cl', 'commclass_id', 'accession_code'),
+  ('commConcept', 'cc', 'commconcept_id', 'accession_code'),
+  ('commStatus', 'cs', 'commstatus_id', 'accession_code'),
+  ('coverMethod', 'cm', 'covermethod_id', 'accession_code'),
+  ('namedPlace', 'np', 'namedplace_id', 'accession_code'),
+  ('observation', 'ob', 'observation_id', 'accession_code'),
+  ('party', 'py', 'party_id', 'accession_code'),
+  ('plantConcept', 'pc', 'plantconcept_id', 'accession_code'),
+  ('plantStatus', 'ps', 'plantstatus_id', 'accession_code'),
+  ('plot', 'pl', 'plot_id', 'accession_code'),
+  ('project', 'pj', 'project_id', 'accession_code'),
+  ('reference', 'rf', 'reference_id', 'accession_code'),
+  ('referenceJournal', 'rj', 'referencejournal_id', 'accession_code'),
+  ('referenceParty', 'rp', 'referenceparty_id', 'accession_code'),
+  ('soilTaxon', 'st', 'soiltaxon_id', 'accession_code'),
+  ('stratumMethod', 'sm', 'stratummethod_id', 'accession_code'),
+  ('taxonObservation', 'to', 'taxonobservation_id', 'accession_code'),
+  ('taxonInterpretation', 'ti', 'taxoninterpretation_id', 'accession_code'),
+  ('userDefined', 'ud', 'userdefined_id', 'accession_code'),
+  ('aux_role', 'ar', 'role_id', 'vb_code'),
+  ('commClass', 'cl', 'commclass_id', 'vb_code'),
+  ('commConcept', 'cc', 'commconcept_id', 'vb_code'),
+  ('commStatus', 'cs', 'commstatus_id', 'vb_code'),
+  ('coverMethod', 'cm', 'covermethod_id', 'vb_code'),
+  ('namedPlace', 'np', 'namedplace_id', 'vb_code'),
+  ('observation', 'ob', 'observation_id', 'vb_code'),
+  ('party', 'py', 'party_id', 'vb_code'),
+  ('plantConcept', 'pc', 'plantconcept_id', 'vb_code'),
+  ('plantStatus', 'ps', 'plantstatus_id', 'vb_code'),
+  ('plot', 'pl', 'plot_id', 'vb_code'),
+  ('project', 'pj', 'project_id', 'vb_code'),
+  ('reference', 'rf', 'reference_id', 'vb_code'),
+  ('soilTaxon', 'st', 'soiltaxon_id', 'vb_code'),
+  ('stratumMethod', 'sm', 'stratummethod_id', 'vb_code'),
+  ('stratumType', 'sy', 'stratumtype_id', 'vb_code'),
+  ('taxonObservation', 'to', 'taxonobservation_id', 'vb_code'),
+  ('taxonInterpretation', 'ti', 'taxoninterpretation_id', 'vb_code');

--- a/helm/db/migrations/V1.8__populate_acc_identifiers_procedure.sql
+++ b/helm/db/migrations/V1.8__populate_acc_identifiers_procedure.sql
@@ -3,36 +3,8 @@
 -- with the 'accession_code' identifier_type
 ----------------------------------------------------------------------------
 
--- Create a mapping table to iterate over for an the identifier import procedure
-CREATE TABLE acc_code_source_map (
-  source_table TEXT NOT NULL,   -- table name
-  table_code   TEXT NOT NULL,   -- short code for the table
-  pk_column    TEXT NOT NULL,   -- primary key column of the source table
-  id_type      TEXT NOT NULL    -- identifier type (e.g., AccessionCode)
-);
-
--- Manually insert the mapping data
-INSERT INTO acc_code_source_map (source_table, table_code, pk_column, id_type) VALUES
-  ('aux_role', 'ar', 'role_id', 'accession_code'),
-  ('commClass', 'cl', 'commclass_id', 'accession_code'),
-  ('commConcept', 'cc', 'commconcept_id', 'accession_code'),
-  ('commStatus', 'cs', 'commstatus_id', 'accession_code'),
-  ('coverMethod', 'cm', 'covermethod_id', 'accession_code'),
-  ('namedPlace', 'np', 'namedplace_id', 'accession_code'),
-  ('observation', 'ob', 'observation_id', 'accession_code'),
-  ('party', 'py', 'party_id', 'accession_code'),
-  ('plantConcept', 'pc', 'plantconcept_id', 'accession_code'),
-  ('plantStatus', 'ps', 'plantstatus_id', 'accession_code'),
-  ('plot', 'pl', 'plot_id', 'accession_code'),
-  ('project', 'pj', 'project_id', 'accession_code'),
-  ('reference', 'rf', 'reference_id', 'accession_code'),
-  ('referenceJournal', 'rj', 'referencejournal_id', 'accession_code'),
-  ('referenceParty', 'rp', 'referenceparty_id', 'accession_code'),
-  ('soilTaxon', 'st', 'soiltaxon_id', 'accession_code'),
-  ('stratumMethod', 'sm', 'stratummethod_id', 'accession_code'),
-  ('taxonObservation', 'to', 'taxonobservation_id', 'accession_code'),
-  ('taxonInterpretation', 'ti', 'taxoninterpretation_id', 'accession_code'),
-  ('userDefined', 'ud', 'userdefined_id', 'accession_code');
+CREATE VIEW acc_code_source_map AS
+SELECT * FROM identifiers_source_map WHERE id_type = 'accession_code';
 
 CREATE OR REPLACE PROCEDURE populate_acc_code_identifiers()
 LANGUAGE plpgsql -- PL/pgSQL is used for dynamic or iterative logic, rather than a static query

--- a/helm/db/migrations/V1.9__populate_vb_identifiers_procedure.sql
+++ b/helm/db/migrations/V1.9__populate_vb_identifiers_procedure.sql
@@ -3,34 +3,8 @@
 -- with the new 'vb_code' identifier_type
 ----------------------------------------------------------------------------
 
--- Create a mapping table to iterate over for the vb_code procedure
-CREATE TABLE vb_code_source_map (
-  source_table TEXT NOT NULL,   -- table name
-  table_code   TEXT NOT NULL,   -- short code for the table
-  pk_column    TEXT NOT NULL,   -- primary key column of the source table
-  id_type      TEXT NOT NULL    -- identifier type (e.g., AccessionCode)
-);
-
--- Manually insert the required vb_code table data
-INSERT INTO vb_code_source_map (source_table, table_code, pk_column, id_type) VALUES
-  ('aux_role', 'ar', 'role_id', 'vb_code'),
-  ('commClass', 'cl', 'commclass_id', 'vb_code'),
-  ('commConcept', 'cc', 'commconcept_id', 'vb_code'),
-  ('commStatus', 'cs', 'commstatus_id', 'vb_code'),
-  ('coverMethod', 'cm', 'covermethod_id', 'vb_code'),
-  ('namedPlace', 'np', 'namedplace_id', 'vb_code'),
-  ('observation', 'ob', 'observation_id', 'vb_code'),
-  ('party', 'py', 'party_id', 'vb_code'),
-  ('plantConcept', 'pc', 'plantconcept_id', 'vb_code'),
-  ('plantStatus', 'ps', 'plantstatus_id', 'vb_code'),
-  ('plot', 'pl', 'plot_id', 'vb_code'),
-  ('project', 'pj', 'project_id', 'vb_code'),
-  ('reference', 'rf', 'reference_id', 'vb_code'),
-  ('soilTaxon', 'st', 'soiltaxon_id', 'vb_code'),
-  ('stratumMethod', 'sm', 'stratummethod_id', 'vb_code'),
-  ('stratumType', 'sy', 'stratumtype_id', 'vb_code'),
-  ('taxonObservation', 'to', 'taxonobservation_id', 'vb_code'),
-  ('taxonInterpretation', 'ti', 'taxoninterpretation_id', 'vb_code');
+CREATE VIEW vb_code_source_map AS
+SELECT * FROM identifiers_source_map WHERE id_type = 'vb_code';
 
 CREATE OR REPLACE PROCEDURE populate_vb_code_identifiers()
 LANGUAGE plpgsql -- PL/pgSQL is used for dynamic or iterative logic, rather than a static query


### PR DESCRIPTION
**Summary of Changes:**
- Added 3 new migration files:
    - V1.7 which creates the `identifiers` table, and a `identifier_source_map` table which contains a map of tables that contain `accession_code`s that need to be backfilled
    - V1.8 which contains a procedure (dynamic sql) to iterate over the `identifier_source_map` and populate/backfill the `identifiers` table with the pre-existing data
    - V1.9 which creates a `vb_code_source_map` table which is iterated over by a procedure that populates the `identifiers` table with the new desired `vb_codes` for the specified tables