### PR TITLE
Add Plant Concept retrieval endpoints

### DIFF
--- a/helm/Chart.yaml
+++ b/helm/Chart.yaml
@@ -24,7 +24,7 @@ version: "0.0.1"
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "0.0.3-feature-70.1"
+appVersion: "0.0.3-feature-85"
 
 dependencies: 
 - name: postgresql

--- a/queries/plant_concept/get_plant_concept_by_pc_code.sql
+++ b/queries/plant_concept/get_plant_concept_by_pc_code.sql
@@ -1,0 +1,55 @@
+WITH pn AS (
+  SELECT plantconcept_id,
+         JSON_OBJECT_AGG(classsystem, RTRIM(plantname)) AS usage_names,
+         JSON_OBJECT_AGG(classsystem, plantnamestatus) AS usage_statuses
+    FROM plantusage
+    GROUP BY plantconcept_id
+), ps AS (
+  SELECT *
+  FROM (
+    SELECT
+        *,
+        ROW_NUMBER() OVER(PARTITION BY plantconcept_id
+                          ORDER BY startdate DESC) as rn
+    FROM
+        plantstatus)
+  WHERE rn = 1
+)
+SELECT 'pc.' || pc.plantconcept_id AS pc_code,
+       pc.plantname AS plant_name,
+       pn.usage_names ->> 'Code' AS plant_code,
+       pc.plantdescription AS plant_description,
+       'rf.' || pc.reference_id AS concept_rf_code,
+       rf_pc.shortname AS concept_rf_name,
+       'rf.' || ps.reference_id AS status_rf_code,
+       rf_ps.shortname AS status_rf_name,
+       pn.usage_names::text AS usage_names,
+       pn.usage_statuses::text AS usage_statuses,
+       pc.d_obscount as obs_count,
+       ps.plantlevel AS plant_level,
+       ps.plantconceptstatus AS status,
+       ps.startdate AS start_date,
+       ps.stopdate AS stop_date,
+       (ps.stopdate IS NULL OR now() < ps.stopdate) AND
+         LOWER(ps.plantconceptstatus) = 'accepted' AS current_accepted,
+       'py.' || py.party_id AS py_code,
+       COALESCE(py.surname, py.organizationname) AS party,
+       ps.plantpartycomments AS plant_party_comments,
+       'pc.' || ps.plantparent_id AS parent_pc_code,
+       pa.plantname AS parent_name,
+       children::text AS children
+  FROM plantconcept pc
+  LEFT JOIN pn USING (plantconcept_id)
+  LEFT JOIN ps USING(plantconcept_id)
+  LEFT JOIN plantconcept pa ON (pa.plantconcept_id = ps.plantparent_id)
+  LEFT JOIN reference rf_pc ON pc.reference_id = rf_pc.reference_id
+  LEFT JOIN reference rf_ps ON ps.reference_id = rf_ps.reference_id
+  LEFT JOIN party py ON py.party_id = ps.party_id
+  LEFT JOIN (
+    SELECT plantparent_id AS parent_id,
+           JSON_OBJECT_AGG('pc.' || plantconcept_id, plantname) AS children
+      FROM plantstatus ch_status
+      JOIN plantconcept ch_concept USING (plantconcept_id)
+      GROUP BY plantparent_id
+    ) children ON children.parent_id = pc.plantconcept_id
+  WHERE pc.plantconcept_id = %s;

--- a/queries/plant_concept/get_plant_concepts_count.sql
+++ b/queries/plant_concept/get_plant_concepts_count.sql
@@ -1,0 +1,4 @@
+SELECT
+    count(*)
+FROM
+    plantConcept;

--- a/queries/plant_concept/get_plant_concepts_full.sql
+++ b/queries/plant_concept/get_plant_concepts_full.sql
@@ -1,0 +1,56 @@
+WITH pn AS (
+  SELECT plantconcept_id,
+         JSON_OBJECT_AGG(classsystem, RTRIM(plantname)) AS usage_names,
+         JSON_OBJECT_AGG(classsystem, plantnamestatus) AS usage_statuses
+    FROM plantusage
+    GROUP BY plantconcept_id
+), ps AS (
+  SELECT *
+  FROM (
+    SELECT
+        *,
+        ROW_NUMBER() OVER(PARTITION BY plantconcept_id
+                          ORDER BY startdate DESC) as rn
+    FROM
+        plantstatus)
+  WHERE rn = 1
+)
+SELECT 'pc.' || pc.plantconcept_id AS pc_code,
+       pc.plantname AS plant_name,
+       pn.usage_names ->> 'Code' AS plant_code,
+       pc.plantdescription AS plant_description,
+       'rf.' || pc.reference_id AS concept_rf_code,
+       rf_pc.shortname AS concept_rf_name,
+       'rf.' || ps.reference_id AS status_rf_code,
+       rf_ps.shortname AS status_rf_name,
+       pn.usage_names::text AS usage_names,
+       pn.usage_statuses::text AS usage_statuses,
+       pc.d_obscount as obs_count,
+       ps.plantlevel AS plant_level,
+       ps.plantconceptstatus AS status,
+       ps.startdate AS start_date,
+       ps.stopdate AS stop_date,
+       (ps.stopdate IS NULL OR now() < ps.stopdate) AND
+         LOWER(ps.plantconceptstatus) = 'accepted' AS current_accepted,
+       'py.' || py.party_id AS py_code,
+       COALESCE(py.surname, py.organizationname) AS party,
+       ps.plantpartycomments AS plant_party_comments,
+       'pc.' || ps.plantparent_id AS parent_pc_code,
+       pa.plantname AS parent_name,
+       children::text AS children
+  FROM plantconcept pc
+  LEFT JOIN pn USING (plantconcept_id)
+  LEFT JOIN ps USING(plantconcept_id)
+  LEFT JOIN plantconcept pa ON (pa.plantconcept_id = ps.plantparent_id)
+  LEFT JOIN reference rf_pc ON pc.reference_id = rf_pc.reference_id
+  LEFT JOIN reference rf_ps ON ps.reference_id = rf_ps.reference_id
+  LEFT JOIN party py ON py.party_id = ps.party_id
+  LEFT JOIN (
+    SELECT plantparent_id AS parent_id,
+           JSON_OBJECT_AGG('pc.' || plantconcept_id, plantname) AS children
+      FROM plantstatus ch_status
+      JOIN plantconcept ch_concept USING (plantconcept_id)
+      GROUP BY plantparent_id
+    ) children ON children.parent_id = pc.plantconcept_id
+  LIMIT %s
+  OFFSET %s;

--- a/vegbank/operators/PlantConcept.py
+++ b/vegbank/operators/PlantConcept.py
@@ -1,0 +1,122 @@
+import os
+import re
+from operators import Operator
+from utilities import jsonify_error_message, QueryParameterError
+
+
+class PlantConcept(Operator):
+    '''
+    Defines operations related to the exchange of plant concept data with
+    Vegbank, including usage and status (party perspective) information.
+
+    Plant Concept: A definition of a named plant taxon according to a reference.
+    Plant Usages: Particular names associated with a plant concept, and the
+    effective dates, status, and system for that name.
+    Plant Status: The asserted status of a concept, according to a party
+    (a.k.a., a party perspective).
+
+    Inherits from the Operator parent class to utilize common default values.
+    '''
+
+    def __init__(self, params):
+        super().__init__(params)
+        self.name = "plant_concept"
+        self.QUERIES_FOLDER = os.path.join(self.QUERIES_FOLDER, self.name)
+
+    def validate_query_params(self, request_args):
+        """
+        Validate query parameters and apply defaults to missing parameters.
+
+        Checks that all provided parameters have correct types and values within
+        acceptable ranges. Missing parameters are set to their default values.
+
+        Parameters:
+            request_args (ImmutableMultiDict): Query parameters provided
+                as part of the request.
+
+        Returns:
+            dict: A dictionary of validated parameters with defaults applied.
+
+        Raises:
+            QueryParameterError: If any supplied parameters are invalid.
+
+        Example:
+            >>> args = ImmutableMultiDict([('limit', '10')])
+            >>> result = self.validate_query_params(args)
+            >>> result
+            {'limit': 10, 'offset': 0, 'detail': 'full'}
+        """
+        params = {}
+        params['create_parquet'] = request_args.get("create_parquet", "false").lower() == "true"
+        params['detail'] = request_args.get("detail", self.default_detail)
+        if params['detail'] not in ("full"):
+            raise QueryParameterError("When provided, 'detail' must be 'full'.")
+        try:
+            params['limit'] = int(request_args.get("limit", self.default_limit))
+            params['offset'] = int(request_args.get("offset", self.default_offset))
+        except ValueError:
+            raise QueryParameterError("When provided, 'offset' and 'limit' must be non-negative integers.")
+        if params['limit'] < 0 or params['offset'] < 0:
+            raise QueryParameterError("When provided, 'offset' and 'limit' must be non-negative integers.")
+        return params
+
+    def get_plant_concepts(self, request, pc_code):
+        """
+        Retrieve either an individual plant concept or a collection.
+
+        If a valid pc_code is provided, returns the corresponding record if it
+        exists. If no pc_code is provided, returns the full collection of
+        concept records with pagination and field scope controlled by query
+        parameters.
+
+        Parameters:
+            request (flask.Request): The Flask request object containing query
+                parameters.
+            pc_code (str or None): The unique identifier for the plant concept
+                being retrieved. If None, retrieves all plant concepts.
+
+        Query Parameters:
+            detail (str, optional): Level of detail for the response.
+                Only 'full' is defined for this method. Defaults to 'full'.
+            limit (int, optional): Maximum number of records to return.
+                Defaults to 1000.
+            offset (int, optional): Number of records to skip before starting
+                to return records. Defaults to 0.
+            create_parquet (str, optional): Whether to return data as Parquet
+                rather than JSON. Accepts 'true' or 'false' (case-insensitive).
+                Defaults to False.
+
+        Returns:
+            flask.Response: A Flask response object containing:
+                - For individual concepts: Plant concept data as JSON or Parquet
+                - For collection concepts: Plant concept data as JSON or Parquet,
+                  with associated record count if JSON
+                - For invalid parameters: JSON error message with 400 status code
+        """
+
+        try:
+            params = self.validate_query_params(request.args)
+        except QueryParameterError as e:
+            return jsonify_error_message(e.message), e.status_code
+
+        if pc_code is None:
+            with open(os.path.join(self.QUERIES_FOLDER, "get_plant_concepts_full.sql"), "r") as file:
+                sql = file.read()
+            with open(os.path.join(self.QUERIES_FOLDER, "get_plant_concepts_count.sql"), "r") as file:
+                count_sql = file.read()
+            data = (params['limit'], params['offset'], )
+        else:
+            pc_id_match = re.match(r'^pc\.(\d+)$', pc_code)
+            if pc_id_match is None:
+                return jsonify_error_message(f"Invalid plant concept code '{pc_code}'."), 400
+            else:
+                pc_id = int(pc_id_match.group(1))
+            with open(os.path.join(self.QUERIES_FOLDER, "get_plant_concept_by_pc_code.sql"), "r") as file:
+                sql = file.read()
+            count_sql = None
+            data = (pc_id, )
+
+        if params['create_parquet']:
+            return self.create_parquet_response(sql, data)
+        else:
+            return self.create_json_response(sql, data, count_sql)

--- a/vegbank/operators/__init__.py
+++ b/vegbank/operators/__init__.py
@@ -4,6 +4,7 @@ from .CommunityClassification import CommunityClassification
 from .CommunityConcept import CommunityConcept
 from .CoverMethod import CoverMethod
 from .Party import Party
+from .PlantConcept import PlantConcept
 from .PlotObservation import PlotObservation
 from .Project import Project
 from .StratumMethod import StratumMethod

--- a/vegbank/operators/__init__.py
+++ b/vegbank/operators/__init__.py
@@ -1,0 +1,10 @@
+from .operator_parent_class import Operator
+
+from .CommunityClassification import CommunityClassification
+from .CommunityConcept import CommunityConcept
+from .CoverMethod import CoverMethod
+from .Party import Party
+from .PlotObservation import PlotObservation
+from .Project import Project
+from .StratumMethod import StratumMethod
+from .TaxonObservation import TaxonObservation

--- a/vegbank/operators/operator_parent_class.py
+++ b/vegbank/operators/operator_parent_class.py
@@ -6,29 +6,56 @@ from psycopg.rows import dict_row
 from utilities import convert_to_parquet
 
 class Operator:
-    '''
-    A super class for all operators to inherit from and define common default values.
+    """
+    Parent class for operators to inherit from and define common default values.
+
+    This class provides a base implementation for database operators that handle
+    SQL queries and response formatting.
+
     Attributes:
-        QUERIES_FOLDER: str: The folder path where SQL query files are stored.
-        default_detail: str: The default detail level for responses, set to "full".
-        default_limit: str: The default limit for number of records to return, set to "1000".
-        default_offset: str: The default offset for number of records to skip, set to "0".
-        params: dict: Database connection parameters.
-        name: str: Simple name used for SQL file load paths and returned file names.
-    '''
+        QUERIES_FOLDER (str): Path where SQL query files are stored
+        default_detail (str): Default detail level for responses
+        default_limit (str): Default limit for number of records to return
+        default_offset (str): Default offset for number of records to skip
+        params (dict or None): Database connection parameters containing
+            dbname, user, host, port, and password
+        name (str): Name used for SQL file load paths and returned file names
+    """
 
     def __init__(self, params=None):
-        '''
+        """
         Initialize common default values for all operators.
-        '''
+
+        Parameters:
+            params (dict, optional): Database connection parameters.
+                Expected to contain: dbname, user, host, port, password.
+                Defaults to None.
+        """
         self.QUERIES_FOLDER = "queries/"
         self.default_detail = "full"
-        self.default_limit = "1000"
-        self.default_offset = "0"
+        self.default_limit = 1000
+        self.default_offset = 0
         self.params = params
         self.name = "vegbank"
 
     def create_json_response(self, sql, data, count_sql):
+        """
+        Execute a database query and return results as a JSON response
+
+        If count_sql is provided, an additional query will be executed to
+        obtain a record count along with the actual data records.
+
+        Parameters:
+            sql (str): Main SQL query to retrieve data records.
+            data (tuple): Query parameters to be substituted into the SQL query.
+            count_sql (str or None): Optional SQL query to count total records.
+                If None, count is determined from the length of returned data.
+
+        Returns:
+            flask.Response: A Flask JSON response containing:
+                - data (list): List of database records as dictionaries
+                - count (int): Total record count (from count_sql or len(data))
+        """
         to_return = {}
         with psycopg.connect(**self.params, cursor_factory=ClientCursor) as conn:
             conn.row_factory=dict_row
@@ -44,6 +71,16 @@ class Operator:
         return jsonify(to_return)
 
     def create_parquet_response(self, sql, data):
+        """
+        Execute a database query and return results as a Parquet response
+
+        Parameters:
+            sql (str): Main SQL query to retrieve data records.
+            data (tuple): Query parameters to be substituted into the SQL query.
+
+        Returns:
+            flask.Response: A Flask Parquet response containing the data
+        """
         with psycopg.connect(**self.params, cursor_factory=ClientCursor) as conn:
             df_parquet = convert_to_parquet(sql, data, conn)
         return send_file(io.BytesIO(df_parquet),

--- a/vegbank/operators/operator_parent_class.py
+++ b/vegbank/operators/operator_parent_class.py
@@ -1,15 +1,23 @@
+import io
+from flask import jsonify, send_file
+import psycopg
+from psycopg import ClientCursor
+from psycopg.rows import dict_row
+from utilities import convert_to_parquet
+
 class Operator:
     '''
     A super class for all operators to inherit from and define common default values.
-    Attributes: 
+    Attributes:
         QUERIES_FOLDER: str: The folder path where SQL query files are stored.
         default_detail: str: The default detail level for responses, set to "full".
         default_limit: str: The default limit for number of records to return, set to "1000".
         default_offset: str: The default offset for number of records to skip, set to "0".
+        params: dict: Database connection parameters.
+        name: str: Simple name used for SQL file load paths and returned file names.
     '''
 
-    
-    def __init__(self):
+    def __init__(self, params=None):
         '''
         Initialize common default values for all operators.
         '''
@@ -17,3 +25,28 @@ class Operator:
         self.default_detail = "full"
         self.default_limit = "1000"
         self.default_offset = "0"
+        self.params = params
+        self.name = "vegbank"
+
+    def create_json_response(self, sql, data, count_sql):
+        to_return = {}
+        with psycopg.connect(**self.params, cursor_factory=ClientCursor) as conn:
+            conn.row_factory=dict_row
+            with conn.cursor() as cur:
+                cur.execute(sql, data)
+                to_return["data"] = cur.fetchall()
+                if count_sql is not None:
+                    cur.execute(count_sql)
+                    to_return["count"] = cur.fetchall()[0]["count"]
+                else:
+                    to_return["count"] = len(to_return["data"])
+            conn.close()
+        return jsonify(to_return)
+
+    def create_parquet_response(self, sql, data):
+        with psycopg.connect(**self.params, cursor_factory=ClientCursor) as conn:
+            df_parquet = convert_to_parquet(sql, data, conn)
+        return send_file(io.BytesIO(df_parquet),
+                         mimetype='application/octet-stream',
+                         as_attachment=True,
+                         download_name=f'{self.name}.parquet')

--- a/vegbank/operators/operator_parent_class.py
+++ b/vegbank/operators/operator_parent_class.py
@@ -58,7 +58,7 @@ class Operator:
         """
         to_return = {}
         with psycopg.connect(**self.params, cursor_factory=ClientCursor) as conn:
-            conn.row_factory=dict_row
+            conn.row_factory = dict_row
             with conn.cursor() as cur:
                 cur.execute(sql, data)
                 to_return["data"] = cur.fetchall()
@@ -67,7 +67,6 @@ class Operator:
                     to_return["count"] = cur.fetchall()[0]["count"]
                 else:
                     to_return["count"] = len(to_return["data"])
-            conn.close()
         return jsonify(to_return)
 
     def create_parquet_response(self, sql, data):

--- a/vegbank/utilities.py
+++ b/vegbank/utilities.py
@@ -48,3 +48,11 @@ def jsonify_error_message(message):
             "message": message
         }
     })
+
+
+class QueryParameterError(Exception):
+    """Exception raised for invalid query parameters."""
+    def __init__(self, message, status_code=400):
+        self.message = message
+        self.status_code = status_code
+        super().__init__(self.message)

--- a/vegbank/vegbankapi.py
+++ b/vegbank/vegbankapi.py
@@ -9,14 +9,16 @@ import time
 import traceback
 import os
 from utilities import jsonify_error_message, convert_to_parquet, allowed_file
-from operators.TaxonObservation import TaxonObservation
-from operators.PlotObservation import PlotObservation
-from operators.Party import Party
-from operators.CommunityClassification import CommunityClassification
-from operators.CommunityConcept import CommunityConcept
-from operators.CoverMethod import CoverMethod
-from operators.Project import Project
-from operators.StratumMethod import StratumMethod
+from operators import (
+    TaxonObservation,
+    PlotObservation,
+    Party,
+    CommunityClassification,
+    CommunityConcept,
+    CoverMethod,
+    Project,
+    StratumMethod,
+)
 
 
 UPLOAD_FOLDER = '/vegbank2/uploads' #For future use with uploading parquet files if necessary

--- a/vegbank/vegbankapi.py
+++ b/vegbank/vegbankapi.py
@@ -13,6 +13,7 @@ from operators import (
     TaxonObservation,
     PlotObservation,
     Party,
+    PlantConcept,
     CommunityClassification,
     CommunityConcept,
     CoverMethod,
@@ -213,6 +214,39 @@ def community_concepts(accession_code):
     else:
         return jsonify_error_message("Method not allowed. Use GET or POST."), 405
 
+
+@app.route("/plant-concepts", defaults={'pc_code': None}, methods=['GET', 'POST'])
+@app.route("/plant-concepts/<pc_code>")
+def plant_concepts(pc_code):
+    '''
+    Retrieve either an individual plant concept or a collection of concepts.
+
+    This function handles HTTP requests for plant concepts. It currently
+    supports only the GET method to retrieve plant concepts. If a POST
+    request is made, it returns an error message indicating that POST is
+    not supported. For any other HTTP method, it returns a 405 error.
+
+    See the PlantConcept operator for more details.
+
+    Parameters:
+        pc_code (str or None): The unique identifier for the plant concept
+            being retrieved. If None, retrieves all plant concepts.
+
+    Returns:
+        flask.Response: A Flask response object containing:
+            - For individual concepts: Plant concept data as JSON or Parquet
+            - For collection concepts: Plant concept data as JSON or Parquet,
+              with associated record count if JSON
+            - For invalid parameters: JSON error message with 400 status code
+            - For unsupported HTTP method: JSON error message with 405 status code
+    '''
+    plant_concept_operator = PlantConcept(params)
+    if request.method == 'POST':
+        return jsonify_error_message("POST method is not supported for plant concepts."), 405
+    elif request.method == 'GET':
+        return plant_concept_operator.get_plant_concepts(request, pc_code)
+    else:
+        return jsonify_error_message("Method not allowed. Use GET or POST."), 405
 
 @app.route("/parties", defaults={'accession_code': None}, methods=['GET', 'POST'])
 @app.route("/parties/<accession_code>", methods=['GET'])


### PR DESCRIPTION
### What

Add new Plant Concept `GET` endpoints for retrieving either an individual plant concept by pc_code, or all plant concepts in paginated sets. Response data can either be in JSON or Parquet format, currently as controlled by a query parameter (in line with the existing Projects implementation).

### Why

So API clients can query for either one or all plant concepts!

### How

- Enhanced and extended the base Operator class, adding new methods to execute queries and return results either as JSON or Parquet. Also changed up the handling of DB configuration parameters (albeit without changing the behavior of other existing operators) and SQL query file path resolution, and did a bit more work on the docstrings.
- Added a new `PlantConcept` operator class. This operator introduces a new method for doing request parameter validation, raising a custom QueryParameterError exception if validation fails, and also uses the new base Operator methods for executing queries and creating JSON or Parquet responses.
- Added relevant SQL queries.
- Added new `plant-concepts` routes and corresponding Flask view function to connect the routes to the backend operator functionality and database queries.
- Also added an `__init__.py` file to simplify loading of Operators -- but haven't actually simplified the import statements in other modules beyond those involved directly in this PR.

Note that this endpoint deviates from other existing `GET` endpoints by retrieving Plant Concepts by their *vb_code* (per new design) rather than by accession code. Future plan is to switch over the remaining endpoints.

### Testing

For now, until our test automation gets set up (#58), testing has been a manual affair. I tested locally on a copy of the database to check for the expected responses in these cases:
- Single record, JSON format
- Single record, Parquet format
- Collection, JSON format, with various limit and offset combinations
- Collection, Parquet format, with various limit and offset combinations
- Malformed pc_code (i.e., anything other than `pc.<integer>`
- Invalid `GET` query parameters (especially limit, offset)
- Unsupported HTTP method (`POST` or `PUT`)

Also tested using the `vegbankr` integration test [here](https://github.com/NCEAS/vegbankr/blob/develop/tests/testthat/test-actual-api.R), which doesn't actually have any tests for the new plant concept endpoints because that functionality hasn't been fully implemented in the R package yet. But this does add confidence that the changes here don't break other unrelated parts of the API. And I do have WIP R functions to hit the new plant concept endpoints running locally; these functions handle both the single record and collection endpoints, and can deal with both JSON and Parquet responses. So far everything seems to be working well.