### PR TITLE
Add new endpoints to get References

### DIFF
--- a/helm/Chart.yaml
+++ b/helm/Chart.yaml
@@ -24,7 +24,7 @@ version: "0.0.1"
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "0.0.3-feature-84"
+appVersion: "0.0.3-feature-81"
 
 dependencies: 
 - name: postgresql

--- a/queries/reference/get_reference_by_id.sql
+++ b/queries/reference/get_reference_by_id.sql
@@ -1,0 +1,17 @@
+SELECT 'rf.' || rf.reference_id AS rf_code,
+       rf.shortname AS short_name,
+       rf.fulltext AS full_citation,
+       rf.referencetype AS reference_type,
+       rf.title AS title,
+       rf.pubdate AS publication_date,
+       rf.totalpages AS total_pages,
+       rf.publisher AS publisher,
+       rf.publicationplace AS publication_place,
+       rf.degree AS degree,
+       rf.isbn AS isbn,
+       rf.url AS url,
+       rf.doi AS doi,
+       rj.journal AS journal
+  FROM reference rf
+  LEFT JOIN referencejournal rj USING (referencejournal_id)
+  WHERE rf.reference_id = %s

--- a/queries/reference/get_reference_count.sql
+++ b/queries/reference/get_reference_count.sql
@@ -1,0 +1,1 @@
+SELECT COUNT(*) FROM reference

--- a/queries/reference/get_reference_full.sql
+++ b/queries/reference/get_reference_full.sql
@@ -1,0 +1,18 @@
+SELECT 'rf.' || rf.reference_id AS rf_code,
+       rf.shortname AS short_name,
+       rf.fulltext AS full_citation,
+       rf.referencetype AS reference_type,
+       rf.title AS title,
+       rf.pubdate AS publication_date,
+       rf.totalpages AS total_pages,
+       rf.publisher AS publisher,
+       rf.publicationplace AS publication_place,
+       rf.degree AS degree,
+       rf.isbn AS isbn,
+       rf.url AS url,
+       rf.doi AS doi,
+       rj.journal AS journal
+  FROM reference rf
+  LEFT JOIN referencejournal rj USING (referencejournal_id)
+  LIMIT %s
+  OFFSET %s

--- a/vegbank/operators/Reference.py
+++ b/vegbank/operators/Reference.py
@@ -1,0 +1,47 @@
+import os
+from operators import Operator
+from utilities import QueryParameterError
+
+
+class Reference(Operator):
+    """
+    Defines operations related to the exchange of cited references with VegBank.
+
+    Reference: A cited source of information used within VegBank, e.g.
+        as required to define plant and community concepts.
+
+    Inherits from the Operator parent class to utilize common default values and
+    methods.
+    """
+
+    def __init__(self, params):
+        super().__init__(params)
+        self.name = "reference"
+        self.table_code = "rf"
+        self.QUERIES_FOLDER = os.path.join(self.QUERIES_FOLDER, self.name)
+        self.full_get_parameters = ('limit', 'offset')
+
+    def validate_query_params(self, request_args):
+        """
+        Validate query parameters and apply defaults to missing parameters.
+
+        This only applies validations specific to references, then
+        dispatches to the parent validation method for more general (and more
+        permissive) validations.
+
+        Parameters:
+            request_args (ImmutableMultiDict): Query parameters provided
+                as part of the request.
+
+        Returns:
+            dict: A dictionary of validated parameters with defaults applied.
+
+        Raises:
+            QueryParameterError: If any supplied parameters are invalid.
+        """
+        # specifically require detail to be "full" for references
+        if request_args.get("detail", self.default_detail) not in ("full"):
+            raise QueryParameterError("When provided, 'detail' must be 'full'.")
+
+        # now dispatch to the base validation method
+        return super().validate_query_params(request_args)

--- a/vegbank/operators/__init__.py
+++ b/vegbank/operators/__init__.py
@@ -7,5 +7,6 @@ from .Party import Party
 from .PlantConcept import PlantConcept
 from .PlotObservation import PlotObservation
 from .Project import Project
+from .Reference import Reference
 from .StratumMethod import StratumMethod
 from .TaxonObservation import TaxonObservation

--- a/vegbank/vegbankapi.py
+++ b/vegbank/vegbankapi.py
@@ -19,6 +19,7 @@ from operators import (
     CoverMethod,
     Project,
     StratumMethod,
+    Reference,
 )
 
 
@@ -445,6 +446,54 @@ def stratum_methods(sm_code):
             return stratum_method_operator.upload_stratum_method(request, params)
     elif request.method == 'GET':
         return stratum_method_operator.get_vegbank_resources(request, sm_code)
+    else:
+        return jsonify_error_message("Method not allowed. Use GET or POST."), 405
+
+
+@app.route("/references", defaults={'rf_code': None}, methods=['GET', 'POST'])
+@app.route("/references/<rf_code>")
+def references(rf_code):
+    """
+    Retrieve either an individual reference or a collection.
+
+    This function handles HTTP requests for references. It currently
+    supports only the GET method to retrieve references. If a POST
+    request is made, it returns an error message indicating that POST is
+    not supported. For any other HTTP method, it returns a 405 error.
+
+    If a valid rf_code is provided, returns the corresponding record if it
+    exists. If no rf_code is provided, returns the full collection of
+    concept records with pagination and field scope controlled by query
+    parameters.
+
+    Parameters:
+        rf_code (str or None): The unique identifier for the reference
+            being retrieved. If None, retrieves all references.
+
+    GET Query Parameters:
+        detail (str, optional): Level of detail for the response.
+            Only 'full' is defined for this method. Defaults to 'full'.
+        limit (int, optional): Maximum number of records to return.
+            Defaults to 1000.
+        offset (int, optional): Number of records to skip before starting
+            to return records. Defaults to 0.
+        create_parquet (str, optional): Whether to return data as Parquet
+            rather than JSON. Accepts 'true' or 'false' (case-insensitive).
+            Defaults to False.
+
+    Returns:
+        flask.Response: A Flask response object containing:
+            - For individual concepts: Reference data as JSON or Parquet
+            - For collection concepts: Reference data as JSON or Parquet,
+              with associated record count if JSON
+            - For invalid parameters: JSON error message with 400 status code
+            - For unsupported HTTP method: JSON error message with 405 status code
+    """
+    reference_operator = Reference(params)
+    if request.method == 'POST':
+        return jsonify_error_message("POST method is not supported for references."), 405
+    elif request.method == 'GET':
+        return reference_operator.get_vegbank_resources(request, rf_code)
     else:
         return jsonify_error_message("Method not allowed. Use GET or POST."), 405
 


### PR DESCRIPTION
### What

Add new `GET` endpoints for retrieving either an individual reference by `rf_code`, or all references in paginated batches. Response data can either be in JSON or Parquet format, currently as controlled by the same `create_parquet` query parameter used in other endpoints.

### Why

So API clients can query for either one or all references!

### How

- Added a new `Reference` operator class that defines reference-specific configuration details and query parameter validation, and added the References module to the operators `__init__.py` file
- Added relevant SQL queries
- Added new `references` routes and a corresponding Flask view function to connect the routes to the backend operator functionality and database queries

### Testing

For now, until our test automation gets set up (#58), testing has been a manual affair. I tested locally on a copy of the database to check for the expected responses in these cases:
- Single record, JSON format
- Single record, Parquet format
- Collection, JSON format, with various limit and offset combinations
- Collection, Parquet format, with various limit and offset combinations
- Malformed rc_code (i.e., anything other than `rc.<integer>`
- Invalid `GET` query parameters (especially limit, offset)
- Unsupported HTTP method (`POST` or `PUT`)

Also tested using the `vegbankr` integration test [here](https://github.com/NCEAS/vegbankr/blob/develop/tests/testthat/test-actual-api.R), with local addition of testing for the new references endpoints.

### Sample JSON response (rf.38265)

```json
{
    "count": 1,
    "data": [
        {
            "degree": null,
            "doi": null,
            "full_citation": "Kittel, G., E. Van Wie, M. Damm, R. Rondeau, S. Kettler, A. McMullen, and J. Sanderson. 1999b. A classification of riparian and wetland plant associations of Colorado: A user's guide to the classification project. Colorado Natural Heritage Program.",
            "isbn": null,
            "journal": null,
            "publication_date": "Fri, 01 Jan 1999 08:00:00 GMT",
            "publication_place": "Colorado, United States",
            "publisher": "Colorado Natural Heritage Program",
            "reference_type": null,
            "rf_code": "rf.38265",
            "short_name": "Kittel et al 1999b",
            "title": "A classification of riparian and wetland plant associations of Colorado: A user's guide to the classification project.",
            "total_pages": null,
            "url": null
        }
    ]
}
```