### PR TITLE
Community concept full text search

### DIFF
--- a/helm/db/migrations/V2.1__enable_community_concept_fts.sql
+++ b/helm/db/migrations/V2.1__enable_community_concept_fts.sql
@@ -1,0 +1,126 @@
+/* ---------------------------------------
+    Community Concept Full Text Search
+--------------------------------------- */
+
+-- Add name search column (and index) to community concept table
+ALTER TABLE commconcept
+  ADD COLUMN search_vector tsvector;
+
+CREATE INDEX idx_commconcept_search
+  ON commconcept USING gin(search_vector);
+
+-- Create function to construct a community name search vector for a
+-- given community concept
+CREATE OR REPLACE FUNCTION build_commconcept_search_vector(p_commconcept_id INTEGER)
+RETURNS tsvector AS $$
+DECLARE
+  result tsvector;
+BEGIN
+  SELECT
+    setweight(to_tsvector('simple', COALESCE(
+      (SELECT string_agg(DISTINCT cn.commname, ' ')
+       FROM commname cn
+       WHERE cn.commname_id = cc.commname_id), '')), 'A') ||
+    setweight(to_tsvector('simple', COALESCE(
+      (SELECT string_agg(DISTINCT cn.commname, ' ')
+       FROM commusage cu
+       JOIN commname cn ON cu.commname_id = cn.commname_id
+       WHERE cu.commconcept_id = cc.commconcept_id), '')), 'A') ||
+    setweight(to_tsvector('simple', COALESCE(cc.commdescription, '')), 'C')
+  INTO result
+  FROM commconcept cc
+  WHERE cc.commconcept_id = p_commconcept_id;
+
+  RETURN result;
+END;
+$$ LANGUAGE plpgsql STABLE;
+
+-- Create function to populate the community search column with a
+-- constructed search vector for a single community concept record
+CREATE OR REPLACE FUNCTION update_commconcept_search_vector(p_commconcept_id INTEGER)
+RETURNS void AS $$
+BEGIN
+  UPDATE commconcept
+  SET search_vector = build_commconcept_search_vector(p_commconcept_id)
+  WHERE commconcept_id = p_commconcept_id;
+END;
+$$ LANGUAGE plpgsql;
+
+-- Trigger for any changes to the commconcept record itself
+CREATE OR REPLACE FUNCTION commconcept_search_trigger()
+RETURNS trigger AS $$
+BEGIN
+  PERFORM update_commconcept_search_vector(NEW.commconcept_id);
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE TRIGGER trg_commconcept_search
+AFTER INSERT OR UPDATE OF commname, commdescription ON commconcept
+FOR EACH ROW
+EXECUTE FUNCTION commconcept_search_trigger();
+
+-- Trigger for commusage changes: Update all community concepts
+-- associated with the modified community usage
+CREATE OR REPLACE FUNCTION commusage_search_trigger()
+RETURNS trigger AS $$
+BEGIN
+  IF TG_OP = 'DELETE' THEN
+    PERFORM update_commconcept_search_vector(OLD.commconcept_id);
+  ELSE
+    PERFORM update_commconcept_search_vector(NEW.commconcept_id);
+  END IF;
+  RETURN COALESCE(NEW, OLD);
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE TRIGGER trg_commusage_search
+AFTER INSERT OR UPDATE OR DELETE ON commusage
+FOR EACH ROW
+EXECUTE FUNCTION commusage_search_trigger();
+
+-- Trigger for commname changes: Update all community concepts
+-- associated with the modified community name either directly, or
+-- indirectly through a community status record
+CREATE OR REPLACE FUNCTION commname_search_trigger()
+RETURNS trigger AS $$
+DECLARE
+  affected_commname_id INTEGER;
+  affected_concepts INTEGER[];
+BEGIN
+  IF TG_OP = 'DELETE' THEN
+    affected_commname_id := OLD.commname_id;
+  ELSE
+    affected_commname_id := NEW.commname_id;
+  END IF;
+
+  SELECT ARRAY_AGG(DISTINCT commconcept_id)
+  INTO affected_concepts
+  FROM (
+    SELECT cc.commconcept_id
+    FROM commconcept cc
+    WHERE cc.commname_id = affected_commname_id
+    UNION
+    SELECT cu.commconcept_id
+    FROM commusage cu
+    WHERE cu.commname_id = affected_commname_id
+  ) AS all_concepts;
+
+  IF affected_concepts IS NOT NULL THEN
+    UPDATE commconcept cc
+    SET search_vector = build_commconcept_search_vector(cc.commconcept_id)
+    WHERE cc.commconcept_id = ANY(affected_concepts);
+  END IF;
+
+  RETURN COALESCE(NEW, OLD);
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE TRIGGER trg_commname_search
+AFTER INSERT OR UPDATE OR DELETE ON commname
+FOR EACH ROW
+EXECUTE FUNCTION commname_search_trigger();
+
+-- Populate search vectors for all current comm concepts
+UPDATE commconcept
+  SET search_vector = build_commconcept_search_vector(commconcept_id);

--- a/vegbank/operators/CommunityConcept.py
+++ b/vegbank/operators/CommunityConcept.py
@@ -27,6 +27,10 @@ class CommunityConcept(Operator):
 
     def configure_query(self, *args, **kwargs):
         base_columns = {'*': "*"}
+        base_columns_search = {
+            'search_rank': "TS_RANK(cc.search_vector, " +
+                           "WEBSEARCH_TO_TSQUERY('simple', %s))"
+        }
         main_columns = {}
         main_columns['full'] = {
             'cc_code': "'cc.' || cc.commconcept_id",
@@ -110,6 +114,10 @@ class CommunityConcept(Operator):
                     'columns': base_columns,
                     'params': []
                 },
+                'search': {
+                    'columns': base_columns_search,
+                    'params': ['search']
+                },
             },
             'from': {
                 'sql': "  FROM commconcept AS cc",
@@ -119,6 +127,12 @@ class CommunityConcept(Operator):
                 "always": {
                     'sql': None,
                     'params': []
+                },
+                'search': {
+                    'sql': """\
+                         cc.search_vector @@ WEBSEARCH_TO_TSQUERY('simple', %s)
+                    """,
+                    'params': ['search']
                 },
                 "cc": {
                     'sql': "cc.commconcept_id = %s",
@@ -133,6 +147,10 @@ class CommunityConcept(Operator):
         self.query['select'] = {
             "always": {
                 'columns': main_columns[self.detail],
+                'params': []
+            },
+            'search': {
+                'columns': {'search_rank': 'cc.search_rank'},
                 'params': []
             },
         }
@@ -164,4 +182,9 @@ class CommunityConcept(Operator):
             raise QueryParameterError("When provided, 'detail' must be 'full'.")
 
         # now dispatch to the base validation method
-        return super().validate_query_params(request_args)
+        params = super().validate_query_params(request_args)
+
+        # capture search parameter, if it exists
+        params['search'] = request_args.get('search')
+
+        return params

--- a/vegbank/vegbankapi.py
+++ b/vegbank/vegbankapi.py
@@ -250,6 +250,7 @@ def community_concepts(cc_code):
             being retrieved. If None, retrieves all community concepts.
 
     GET Query Parameters:
+        search (str, optional): Community name search query.
         detail (str, optional): Level of detail for the response.
             Only 'full' is defined for this method. Defaults to 'full'.
         limit (int, optional): Maximum number of records to return.


### PR DESCRIPTION
### What

This PR is a straightforward clone of [PR 165](https://github.com/NCEAS/vegbank2/pull/165) (which was done for plant concepts), now introducing full text search for **community concepts** via the collection GET endpoint.

### Why

So that API clients can request only community concepts whose names (and to a lesser extent, text description) match a desired search term.

### How
- Added a Flyway migration that does the following:
  - Adds a new denormalized column in the `commconcept` table to store a "document" (`tsvector` type) containing the text substrate for search
  - Creates an index on this new column
  - Defines a function for building these documents, assembled from across the commconcept and commname tables
  - Defines a function for inserting the documents into the new column
  - Defines triggers and corresponding functions for updating that column whenever changes are made to any of the `commconcept` table, `commname` table, or `commstatus` table. All three of these tables play a role in associating relevant textual with community concepts.
  - Applies the insert function to initially populate the column for all existing community concepts
- Updated the Community Concept operator to include the relevant SQL snippets, namely in:
  - the WHERE clause, filtering for matching search
  - the SELECT clause, adding a new search_rank field that indicates the relative match strength
- Updated the query parameter validation method to pass along the `search` parameter

No need to touch any base operator code this time, because this uses what we already added in [PR 165](https://github.com/NCEAS/vegbank2/pull/165).

### More details

Repeating the same details from the earlier Plant Concept FTS PR description:
>Under the hood, this uses the `websearch_to_tsquery()` Postgresql function for converting the client's search term into the correct FTS query. As described in the Postgres documentation, this function uses search syntax "similar to the one used by web search engines", which in simple form searches on individual terms, but can also be used to denote phrases ("like this"), exclusions (-this), and "or" conditions ("this" or "that"). See [here](https://www.postgresql.org/docs/17/textsearch-controls.html) for more detail.
>
>Note that we have _*not*_ implemented any sort of fuzzy or semantic search. If you misspell "seqoia", you won't find what you're looking for.

### Demo

__Search for a word (here just returning the count of matching records)__
```sh
$ http GET 'http://127.0.0.1/community-concepts?search=chaparral&count'
```
```json
{
    "count": 237
}
```

__Search for multiple terms including an exclusion word__
```sh
$ http GET 'http://127.0.0.1/community-concepts?search=island chaparral -quercus' \
    | jq '.data[] | {search_rank, cc_code, comm_name}'
```
```json
{
  "search_rank": 2.7360736E-7,
  "cc_code": "cc.51759",
  "comm_name": "Corethrogyne filaginifolia - Eriogonum elongatum - Eriogonum nudum Dry Meadow Alliance"
}
{
  "search_rank": 0.99071646,
  "cc_code": "cc.49815",
  "comm_name": "Heteromeles arbutifolia - Artemisia californica - Rhus integrifolia - (Salvia brandegeei) Mesic Chaparral"
}
```