### PR TITLE
Project full text search

### DIFF
--- a/helm/db/migrations/V2.2__enable_project_fts.sql
+++ b/helm/db/migrations/V2.2__enable_project_fts.sql
@@ -1,0 +1,56 @@
+/* -----------------------------
+    Project Full Text Search
+----------------------------- */
+
+-- Add name/description search column (and index) to project table
+ALTER TABLE project
+  ADD COLUMN search_vector tsvector;
+
+CREATE INDEX idx_project_search
+  ON project USING gin(search_vector);
+
+-- Create function to construct project search vector for a given project
+CREATE OR REPLACE FUNCTION build_project_search_vector(p_project_id INTEGER)
+RETURNS tsvector AS $$
+DECLARE
+  result tsvector;
+BEGIN
+  SELECT
+    setweight(to_tsvector('simple', COALESCE(pj.projectname, '')), 'A') ||
+    setweight(to_tsvector('simple', COALESCE(pj.projectdescription, '')), 'B')
+  INTO result
+  FROM project pj
+  WHERE pj.project_id = p_project_id;
+
+  RETURN result;
+END;
+$$ LANGUAGE plpgsql STABLE;
+
+-- Create function to populate the project search column with a
+-- constructed search vector for a single project record
+CREATE OR REPLACE FUNCTION update_project_search_vector(p_project_id INTEGER)
+RETURNS void AS $$
+BEGIN
+  UPDATE project
+  SET search_vector = build_project_search_vector(p_project_id)
+  WHERE project_id = p_project_id;
+END;
+$$ LANGUAGE plpgsql;
+
+-- Trigger for any changes to the project record itself
+CREATE OR REPLACE FUNCTION project_search_trigger()
+RETURNS trigger AS $$
+BEGIN
+  PERFORM update_project_search_vector(NEW.project_id);
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE TRIGGER trg_project_search
+AFTER INSERT OR UPDATE OF projectname, projectdescription ON project
+FOR EACH ROW
+EXECUTE FUNCTION project_search_trigger();
+
+-- Populate search vectors for all current projects
+UPDATE project
+  SET search_vector = build_project_search_vector(project_id);

--- a/vegbank/vegbankapi.py
+++ b/vegbank/vegbankapi.py
@@ -444,6 +444,7 @@ def projects(pj_code):
             retrieved. If None, retrieves all projects.
 
     GET Query Parameters:
+        search (str, optional): Project name search query.
         detail (str, optional): Level of detail for the response.
             Only 'full' is defined for this method. Defaults to 'full'.
         limit (int, optional): Maximum number of records to return.


### PR DESCRIPTION
### What

This PR is another clone of [PR 165](https://github.com/NCEAS/vegbank2/pull/165) (which was done for plant concepts), now introducing full text search for **projects** via the collection GET endpoint.

### Why

So that API clients can request only projects whose names (and to a lesser extent, text description) match a desired search term.

### How
- Added a Flyway migration that does the following:
  - Adds a new column in the `project` table to store a "document" (`tsvector` type) containing the text substrate for search
  - Creates an index on this new column
  - Defines a function for building these documents using the `projectname` and `projectdescription` columns
  - Defines a function for inserting the documents into the new column
  - Defines a trigger and corresponding function for updating that column whenever changes are made to either of the source columns
  - Applies the insert function to initially populate the column for all existing projects
- Updated the Project operator to include the relevant SQL snippets, namely in:
  - the WHERE clause, filtering for matching search
  - the SELECT clause, adding a new search_rank field that indicates the relative match strength
- Updated the query parameter validation method to pass along the `search` parameter

### More details

Repeating the same details from the earlier Plant Concept FTS PR description:
>Under the hood, this uses the `websearch_to_tsquery()` Postgresql function for converting the client's search term into the correct FTS query. As described in the Postgres documentation, this function uses search syntax "similar to the one used by web search engines", which in simple form searches on individual terms, but can also be used to denote phrases ("like this"), exclusions (-this), and "or" conditions ("this" or "that"). See [here](https://www.postgresql.org/docs/17/textsearch-controls.html) for more detail.
>
>Note that we have _*not*_ implemented any sort of fuzzy or semantic search. If you misspell "seqoia", you won't find what you're looking for.

### Demo

__Search for a word (here just returning the count of matching records)__
```sh
$ http GET 'http://127.0.0.1/projects?search=california&count'
```
```json
{
    "count": 8
}
```

__Search for multiple terms including an exclusion word__
```sh
$ http GET 'http://127.0.0.1/projects?search=california park -"san diego"' \
    | jq '.data[] | {search_rank, pj_code, project_name, project_description}'
```
```json
{
  "search_rank": 0.6177373,
  "pj_code": "pj.2215",
  "project_name": "Yosemite National Park",
  "project_description": "Yosemite National Park (YOSE) National Park Service Mapping Project in California, United States."
}
```