### PR TITLE
Improve community classification concept labels

### DIFF
--- a/vegbank/operators/CommunityClassification.py
+++ b/vegbank/operators/CommunityClassification.py
@@ -38,7 +38,7 @@ class CommunityClassification(Operator):
         base_columns = {'*': "*"}
         main_columns = {}
         # identify full shallow columns
-        main_columns['full'] = {
+        main_columns['minimal'] = {
             'cl_code': "'cl.' || cl.commclass_id",
             'ob_code': "'ob.' || cl.observation_id",
             'class_start_date': "cl.classstartdate",
@@ -52,20 +52,24 @@ class CommunityClassification(Operator):
             'class_notes': "cl.classnotes",
         }
         # identify minimal shallow colunms
-        main_columns['minimal'] = main_columns['full']
-        # identify full columns with nesting
-        main_columns['full_nested'] = main_columns['full'] | {
+        main_columns['full'] = main_columns['minimal'] | {
+            'author_obs_code': "ob.authorobscode",
+        }
+        # identify full & nested columns with nesting
+        nested_columns = {
             'interpretations': "interpretations",
             'contributors': "contributors",
         }
-        # identify minimal columns with nesting
-        main_columns['minimal_nested'] = main_columns['full_nested']
+        main_columns['full_nested'] = main_columns['full'] | nested_columns
+        main_columns['minimal_nested'] = main_columns['minimal'] | nested_columns
         from_sql = {}
-        from_sql['full'] = """\
+        from_sql['minimal'] = """\
             FROM cl
             LEFT JOIN view_reference_transl rf ON reference_id = cl.classpublication_id
             """
-        from_sql['minimal'] = from_sql['full']
+        from_sql['full'] = from_sql['minimal'].rstrip() + """
+            JOIN observation ob USING (observation_id)
+            """
         from_sql_common_nested =  """
             LEFT JOIN LATERAL (
               SELECT JSON_AGG(JSON_BUILD_OBJECT(
@@ -82,10 +86,11 @@ class CommunityClassification(Operator):
             from_sql_common_nested.rstrip() + """
             LEFT JOIN LATERAL (
               SELECT JSON_AGG(JSON_BUILD_OBJECT(
-                         'ci_code', 'ci.' || comminterpretation_id,
-                         'cc_code', 'cc.' || commconcept_id,
-                         'comm_code', commcode,
-                         'comm_name', commname,
+                         'ci_code', 'ci.' || ci.comminterpretation_id,
+                         'cc_code', 'cc.' || ci.commconcept_id,
+                         'comm_code', code.commname,
+                         'comm_name', cc.commname,
+                         'comm_label', cc.commconcept_id_transl,
                          'class_fit', classfit,
                          'class_confidence', classconfidence,
                          'comm_authority_rf_code', 'rf.' || ci.commauthority_id,
@@ -95,6 +100,16 @@ class CommunityClassification(Operator):
                          'nomenclatural_type', nomenclaturaltype
                        )) AS interpretations
                 FROM comminterpretation ci
+                JOIN view_commconcept_transl cc USING (commconcept_id)
+                LEFT JOIN LATERAL (
+                  SELECT ccode.commname
+                    FROM commusage cu
+                    JOIN commname ccode ON ccode.commname_id = cu.commname_id
+                   WHERE cu.commconcept_id = cc.commconcept_id
+                     AND cu.classsystem = 'Code'
+                   ORDER BY cu.usagestart DESC NULLS LAST
+                   LIMIT 1
+                ) code ON true
                 LEFT JOIN view_reference_transl rf ON rf.reference_id = ci.commauthority_id
                 WHERE ci.commclass_id = cl.commclass_id
             ) AS ci ON true
@@ -103,12 +118,23 @@ class CommunityClassification(Operator):
             from_sql_common_nested.rstrip() + """
             LEFT JOIN LATERAL (
               SELECT JSON_AGG(JSON_BUILD_OBJECT(
-                         'ci_code', 'ci.' || comminterpretation_id,
-                         'cc_code', 'cc.' || commconcept_id,
-                         'comm_code', commcode,
-                         'comm_name', commname
+                         'ci_code', 'ci.' || ci.comminterpretation_id,
+                         'cc_code', 'cc.' || ci.commconcept_id,
+                         'comm_code', code.commname,
+                         'comm_name', cc.commname
                        )) AS interpretations
                 FROM comminterpretation ci
+                JOIN commconcept cc USING (commconcept_id)
+                LEFT JOIN LATERAL (
+                  SELECT ccode.commname
+                    FROM commusage cu
+                    JOIN commname ccode ON ccode.commname_id = cu.commname_id
+                   WHERE cu.commconcept_id = cc.commconcept_id
+                     AND cu.classsystem = 'Code'
+                   ORDER BY cu.usagestart DESC NULLS LAST
+                   LIMIT 1
+                ) code ON true
+                LEFT JOIN view_reference_transl rf ON rf.reference_id = ci.commauthority_id
                 WHERE ci.commclass_id = cl.commclass_id
             ) AS ci ON true
             """


### PR DESCRIPTION
### What

This PR improves the community classifications `GET` endpoint by pulling community names and codes directly from their source tables (rather than from unreliable denormalized fields in the community interpretation table), while also adding new `comm_label` and `author_obs_code` fields to responses when `detail=full`.

### Why

The current logic pulls values from denormalized columns in `comminterpretation` that don't always have the correct values, almost certainly as a consequence of how the community concepts were loaded into VegBank a couple decades ago. See the demo section below for an example. Although we could clean up the database itself, the change here make the queries more robust overall.

### How

Updated the Community Classification operator to generate SQL that does the following:
- Uses `comm_name` from the source `commconcept` record (rather than the denormalized field)
- Uses `comm_code` from the source `commname` record via `commusage` (rather than the denormalized field)
- Adds `comm_label` from `view_commconcept_transl`, when `detail=full`
- Adds `author_obs_code` from `observation`, when `detail=full`

### Demo

#### Previous behavior

_Notice in the `interpretations` nested field that `comm_code` is missing, while `comm_name` contains the string that we would expect to see in the `comm_code` field (and therefore we have no information about the actual community name)._

```sh
$ http GET 'https://api-dev.vegbank.org/community-classifications/cl.1553?with_nested=true'
```
```json
{
    "count": 1,
    "data": [
        {
            "cl_code": "cl.1553",
            "class_notes": null,
            "class_publication_rf_code": null,
            "class_publication_rf_label": null,
            "class_start_date": "Thu, 01 Oct 1998 07:00:00 GMT",
            "class_stop_date": null,
            "contributors": [
                {
                    "party": "Gawler, Sue",
                    "py_code": "py.605",
                    "role": "Classifier"
                }
            ],
            "expert_system": null,
            "inspection": false,
            "interpretations": [
                {
                    "cc_code": "cc.46260",
                    "ci_code": "ci.297",
                    "class_confidence": null,
                    "class_fit": null,
                    "comm_authority_name": null,
                    "comm_authority_rf_code": null,
                    "comm_code": null,
                    "comm_name": "CEGL005094",
                    "nomenclatural_type": false,
                    "notes": "Low Sweet Blueberry Granite Barrens",
                    "type": false
                }
            ],
            "multivariate_analysis": true,
            "ob_code": "ob.2948",
            "table_analysis": false
        }
    ]
}
```

#### Improved behavior

Now we not only get back the correct `comm_name` and `comm_code`, but we also get a `comm_label` (which adds the concept reference to its name). In this default case where `detail=full`, we now also get back a new `author_obs_code` field.

```sh
http GET 'http://127.0.0.1/community-classifications/cl.1553?with_nested=true'
```
```json
{
    "count": 1,
    "data": [
        {
            "author_obs_code": "ACAD.143",
            "cl_code": "cl.1553",
            "class_notes": null,
            "class_publication_rf_code": null,
            "class_publication_rf_label": null,
            "class_start_date": "Thu, 01 Oct 1998 07:00:00 GMT",
            "class_stop_date": null,
            "contributors": [
                {
                    "party": "Gawler, Sue",
                    "py_code": "py.605",
                    "role": "Classifier"
                }
            ],
            "expert_system": null,
            "inspection": false,
            "interpretations": [
                {
                    "cc_code": "cc.46260",
                    "ci_code": "ci.297",
                    "class_confidence": null,
                    "class_fit": null,
                    "comm_authority_name": null,
                    "comm_authority_rf_code": null,
                    "comm_code": "CEGL005094",
                    "comm_label": "Vaccinium angustifolium - Sorbus americana / Sibbaldiopsis tridentata Dwarf-shrubland [NatureServe Biotics 2019]",
                    "comm_name": "Vaccinium angustifolium - Sorbus americana / Sibbaldiopsis tridentata Dwarf-shrubland",
                    "nomenclatural_type": false,
                    "notes": "Low Sweet Blueberry Granite Barrens",
                    "type": false
                }
            ],
            "multivariate_analysis": true,
            "ob_code": "ob.2948",
            "table_analysis": false
        }
    ]
}
```

Notice that when `detail=minimal`, we don't get the `author_obs_code` nor the supplemental `comm_label`, but we still get the correct `comm_name` and `comm_code` fields.

```sh
http GET 'http://127.0.0.1/community-classifications/cl.1553?with_nested=true&detail=minimal'
```
```json
{
    "count": 1,
    "data": [
        {
            "cl_code": "cl.1553",
            "class_notes": null,
            "class_publication_rf_code": null,
            "class_publication_rf_label": null,
            "class_start_date": "Thu, 01 Oct 1998 07:00:00 GMT",
            "class_stop_date": null,
            "contributors": [
                {
                    "party": "Gawler, Sue",
                    "py_code": "py.605",
                    "role": "Classifier"
                }
            ],
            "expert_system": null,
            "inspection": false,
            "interpretations": [
                {
                    "cc_code": "cc.46260",
                    "ci_code": "ci.297",
                    "comm_code": "CEGL005094",
                    "comm_name": "Vaccinium angustifolium - Sorbus americana / Sibbaldiopsis tridentata Dwarf-shrubland"
                }
            ],
            "multivariate_analysis": true,
            "ob_code": "ob.2948",
            "table_analysis": false
        }
    ]
}
```