### PR TITLE
Return ob_code of the replacing plot observation

### DIFF
--- a/api/openapi.yml
+++ b/api/openapi.yml
@@ -2645,6 +2645,10 @@ components:
           type: boolean
           description: "Does this observation have an observation synonym record?"
           example: true
+        replaced_by_ob_code:
+          type: string
+          description: "VegBank identifier of the current plot observation superseding this plot observation, if this observation has been replaced by a newer record"
+          example: "ob.2"
 
     PlotObservationFullNested:
       type: object

--- a/vegbank/operators/PlotObservation.py
+++ b/vegbank/operators/PlotObservation.py
@@ -221,6 +221,7 @@ class PlotObservation(Operator):
             'top_taxon4_name': "ob.toptaxon4name",
             'top_taxon5_name': "ob.toptaxon5name",
             'has_observation_synonym': "ob.hasobservationsynonym",
+            'replaced_by_ob_code': "'ob.' || syn.primaryobservation_id"
         }
         # identify full columns with nesting
         main_columns['full_nested'] = main_columns['full'] | {
@@ -261,6 +262,13 @@ class PlotObservation(Operator):
             LEFT JOIN view_reference_transl rf USING (reference_id)
             LEFT JOIN stratummethod sm USING (stratummethod_id)
             LEFT JOIN covermethod cm USING (covermethod_id)
+            LEFT JOIN LATERAL (
+                SELECT primaryobservation_id
+                  FROM observationsynonym
+                  WHERE synonymobservation_id = ob.observation_id
+                  ORDER BY classstartdate DESC
+                  LIMIT 1
+            ) syn ON TRUE
             """
         from_sql_nested = """
             LEFT JOIN LATERAL (
@@ -749,4 +757,4 @@ class PlotObservation(Operator):
             return jsonify(to_return)
         except Exception as e:
             traceback.print_exc()
-            return jsonify_error_message(str(e)), 500              
+            return jsonify_error_message(str(e)), 500


### PR DESCRIPTION
### What

This PR enhances plot observation `GET` endpoints with a new `replaced_by_ob_code` field that identifies the current superseding plot observation for a given returned record, if that current record has been obsoleted by a newer (replacement) record. This should only be present with the existing `has_observation_synonym` field is `True`.

### Why

So that clients can quickly go to the latest plot observation for any superseded plot observation.

### How

Updated relevant SQL code snippets in the PlotObservation operator.

### Testing & documentation

* Manually validated API responses with a few records with/without revisions, including one with multiple revisions (see Demo section below)
* Locally updated the vegbankr API integration/E2E tests to expect the new field, and verified that they pass
* Updated the OAS document

### Demo

Example of plot observation `ob.26032` which was replaced by `ob.79796`, which itself was then replaced by `ob.113031`. As desired, both old versions point to the new version `replaced_by_ob_code`, while the new version does not have a value in this field.

```sh
$ http GET 'http://127.0.0.1/plot-observations/ob.26032' \
    | jq '.data[] | {has_observation_synonym, replaced_by_ob_code}'
{
  "has_observation_synonym": true,
  "replaced_by_ob_code": "ob.113031"
}

$ http GET 'http://127.0.0.1/plot-observations/ob.79796' \
    | jq '.data[] | {has_observation_synonym, replaced_by_ob_code}'
{
  "has_observation_synonym": true,
  "replaced_by_ob_code": "ob.113031"
}

$ http GET 'http://127.0.0.1/plot-observations/ob.113031' \
    | jq '.data[] | {has_observation_synonym, replaced_by_ob_code}'
{
  "has_observation_synonym": null,
  "replaced_by_ob_code": null
```