### PR TITLE
Add soil observations to plot observation response

### DIFF
--- a/api/openapi.yml
+++ b/api/openapi.yml
@@ -2653,6 +2653,78 @@ components:
     PlotObservationFullNested:
       type: object
       properties:
+        soils:
+          type: array
+          items:
+            type: object
+            properties:
+              horizon:
+                type: string
+                description: "The horizon to which this soil observation applies"
+                example: "B"
+              depth_top:
+                type: number
+                format: float
+                description: "The depth at which the horizon observation starts"
+                example: 84
+              depth_bottom:
+                type: number
+                format: float
+                description: "The depth at which the horizon observation ends"
+                example: 86
+              color:
+                type: string
+                description: "Soil color (USDA guidelines recommended)"
+                example: "10yr 6/6 brown yellow"
+              organic:
+                type: number
+                format: float
+                description: "Percent organic content of the soil; for methods, see the plot observation methods_narrative"
+                example: 13.37
+              texture:
+                type: string
+                description: "Soil texture class. The texture classes sands, loamy sands, and sandy loams (plural terms) correspond to sand, loamy sand, and sandy loam (singular terms) in the textural triangle."
+                example: "Clay Loam"
+              sand:
+                type: number
+                format: float
+                description: "Percent sand in the soil horizon"
+                example: 15.85
+              silt:
+                type: number
+                format: float
+                description: "Percent silt in the soil horizon"
+                example: 3.47
+              clay:
+                type: number
+                format: float
+                description: "Percent clay in the soil horizon"
+                example: 0.68
+              coarse:
+                type: number
+                format: float
+                description: "Percent coarse fragments in the soil, prior to removal for textural analysis"
+                example: 0.13
+              ph:
+                type: number
+                format: float
+                description: "pH of the soil; for methods, see the plot observation methods_narrative"
+                example: 4.3
+              exchange_capacity:
+                type: number
+                format: float
+                description: "Cation exchange capacity; for methods, see the plot observation methods_narrative"
+                example: 3.68
+              base_saturation:
+                type: number
+                format: float
+                description: "Percent base saturation; for methods, see the plot observation          methods_narrative"
+                example: 32.2
+              description:
+                type: string
+                description: "Text description of the soil"
+                example: "Beige sticky clay with gray clay below"
+          description: "Observations on soil horizons made during the plot observation event"
         taxon_count:
           type: integer
           description: "Count of taxon observations associated with this plot observation"

--- a/vegbank/operators/PlotObservation.py
+++ b/vegbank/operators/PlotObservation.py
@@ -230,6 +230,7 @@ class PlotObservation(Operator):
             'taxon_importance_count_returned': "taxon_importance_count_returned",
             'top_taxon_observations': "top_taxon_observations",
             'top_classifications': "top_classifications",
+            'soils': "so.soils",
         }
         # identify minimal columns
         main_columns['minimal'] = {alias:col for alias, col in
@@ -370,6 +371,25 @@ class PlotObservation(Operator):
                      (SELECT COUNT(1)
                         FROM returned_taxon_observations) AS taxon_importance_count_returned
             ) AS txo ON true
+            LEFT JOIN LATERAL (
+              SELECT JSON_AGG(JSON_BUILD_OBJECT(
+                      'description', soildescription,
+                      'horizon', soilhorizon,
+                      'depth_top', soildepthtop,
+                      'depth_bottom', soildepthbottom,
+                      'color', soilcolor,
+                      'organic', soilorganic,
+                      'texture', soiltexture,
+                      'sand', soilsand,
+                      'silt', soilsilt,
+                      'clay', soilclay,
+                      'coarse', soilcoarse,
+                      'ph', soilph,
+                      'exchange_capacity', exchangecapacity,
+                      'base_saturation', basesaturation)) AS soils
+                FROM soilobs
+                WHERE observation_id = ob.observation_id
+            ) AS so ON true
             """
         order_by_sql = {}
         order_by_sql['default'] = f"""\


### PR DESCRIPTION
### What

This PR enhances plot observation `GET` endpoints by returning a new `soils` field with a nested array of soil observation details (if any exist) associated with the plot observation. This is returned only when `detail=full&with_nested=true`.

### Why

So that clients can get all soil details associated with plot observation.

### How

Updated relevant SQL code snippets in the PlotObservation operator.

### Testing & documentation

* Manually validated API responses with a few records with/without soil observations (see Demo section below)
* Locally updated the vegbankr API integration/E2E tests to expect the new field, and verified that they pass
* Updated the OAS document

### Demo

Plot observation with 3 soil detail records:
```sh
$ http GET 'http://127.0.0.1/plot-observations/ob.79030?with_nested=true' \
    | jq '.data[] | {soils}'
```
```json
{
  "soils": [
    {
      "base_saturation": null,
      "clay": null,
      "coarse": null,
      "color": null,
      "depth_bottom": null,
      "depth_top": null,
      "description": null,
      "exchange_capacity": 6.43,
      "horizon": "A",
      "organic": 12.78,
      "ph": 4.22,
      "sand": null,
      "silt": null,
      "texture": null
    },
    {
      "base_saturation": null,
      "clay": null,
      "coarse": null,
      "color": null,
      "depth_bottom": null,
      "depth_top": null,
      "description": null,
      "exchange_capacity": 5.66,
      "horizon": "A",
      "organic": 25.67,
      "ph": 4.41,
      "sand": null,
      "silt": null,
      "texture": null
    },
    {
      "base_saturation": null,
      "clay": 7.56,
      "coarse": null,
      "color": null,
      "depth_bottom": null,
      "depth_top": null,
      "description": null,
      "exchange_capacity": null,
      "horizon": "A",
      "organic": null,
      "ph": null,
      "sand": 40.5,
      "silt": 51.94,
      "texture": null
    }
  ]
}
```

Plot observation with no soil detail records:
```sh
$ http GET 'http://127.0.0.1/plot-observations/ob.143436?with_nested=true' \
    | jq '.data[] | {soils}'
```
```json
{
  "soils": null
}
```