### PR TITLE
Add disturbance observations to plot observation response

### DIFF
--- a/api/openapi.yml
+++ b/api/openapi.yml
@@ -2653,6 +2653,34 @@ components:
     PlotObservationFullNested:
       type: object
       properties:
+        disturbances:
+          type: array
+          items:
+            type: object
+            properties:
+              type:
+                type: string
+                description: "Type of disturbance being reported"
+                example: "Wind event"
+              comment:
+                type: string
+                description: "Description of details of the disturbance and its impact on the vegetation"
+                example: "Hurricane blowdown"
+              intensity:
+                type: string
+                description: "Intensity or degree of the disturbance"
+                example: "Low"
+              age:
+                type: number
+                format: float
+                description: "Estimated time in years since the disturbance event"
+                example: 10
+              extent:
+                type: number
+                format: float
+                description: "Percent of the plot that experienced the event"
+                example: 5
+          description: "Observer estimation of the disturbance history of the plot"
         soils:
           type: array
           items:

--- a/vegbank/operators/PlotObservation.py
+++ b/vegbank/operators/PlotObservation.py
@@ -230,6 +230,7 @@ class PlotObservation(Operator):
             'taxon_importance_count_returned': "taxon_importance_count_returned",
             'top_taxon_observations': "top_taxon_observations",
             'top_classifications': "top_classifications",
+            'disturbances': "di.disturbances",
             'soils': "so.soils",
         }
         # identify minimal columns
@@ -371,6 +372,16 @@ class PlotObservation(Operator):
                      (SELECT COUNT(1)
                         FROM returned_taxon_observations) AS taxon_importance_count_returned
             ) AS txo ON true
+            LEFT JOIN LATERAL (
+              SELECT JSON_AGG(JSON_BUILD_OBJECT(
+                      'type', disturbancetype,
+                      'comment', disturbancecomment,
+                      'intensity', disturbanceintensity,
+                      'age', disturbanceage,
+                      'extent', disturbanceextent)) AS disturbances
+                FROM disturbanceobs
+                WHERE observation_id = ob.observation_id
+            ) AS di ON true
             LEFT JOIN LATERAL (
               SELECT JSON_AGG(JSON_BUILD_OBJECT(
                       'description', soildescription,


### PR DESCRIPTION
### What

This PR enhances plot observation `GET` endpoints by returning a new `disturbances` field with a nested array of disturbance observation details (if any exist) associated with the plot observation. These are returned only when `detail=full&with_nested=true`.

### Why

So that clients can get all disturbance details associated with plot observation.

### How

Updated relevant SQL code snippets in the PlotObservation operator.

### Testing & documentation

* Manually validated API responses with a few records with/without disturbance observations (see Demo section below)
* Locally updated the vegbankr API integration/E2E tests to expect the new field, and verified that they pass
* Updated the OAS document

### Demo

```sh
$ http GET 'http://127.0.0.1/plot-observations/ob.81029?with_nested=true' \
    | jq '.data[] | {disturbances}'
```
```json
{
  "disturbances": [
    {
      "age": null,
      "comment": "Beaver impoundment downstream has likely raised water level (despite flowing water).",
      "extent": 100,
      "intensity": "Medium",
      "type": "Natural, general"
    },
    {
      "age": 40,
      "comment": "Logged, probably clearcut.  The stand appears to have regenerated similar to original.",
      "extent": 100,
      "intensity": "High",
      "type": "Human, general"
    }
  ]
}
```
```sh
$ http GET 'http://127.0.0.1/plot-observations/ob.79030?with_nested=true' \
    | jq '.data[] | {disturbances}'
```
```json
{
  "disturbances": null
}
```