### PR TITLE
Add named places to plot observation response

### DIFF
--- a/api/openapi.yml
+++ b/api/openapi.yml
@@ -2753,6 +2753,28 @@ components:
                 description: "Text description of the soil"
                 example: "Beige sticky clay with gray clay below"
           description: "Observations on soil horizons made during the plot observation event"
+        named_places:
+          type: array
+          items:
+            type: object
+            properties:
+              system:
+                type: string
+                description: "Name of the system of names. The system 'Geographic Name' is an open list, whereas the other systems are generally closed lists defined by a known system with an external authority (e.g., USGSQuad, Continent, Country, State, County, HUC, and Ecoregion)"
+                example: "county"
+              name:
+                type: string
+                description: "The name of a place in or at which a plot is located."
+                example: "Marin"
+              description:
+                type: string
+                description: "Description of a named place. For US county names, this field identifies the containing state."
+                example: "California"
+              code:
+                type: string
+                description: "Optional code for location identification"
+                example: "6041"
+          description: "Named places that a plot may have been located in"
         taxon_count:
           type: integer
           description: "Count of taxon observations associated with this plot observation"

--- a/vegbank/operators/PlotObservation.py
+++ b/vegbank/operators/PlotObservation.py
@@ -232,6 +232,7 @@ class PlotObservation(Operator):
             'top_classifications': "top_classifications",
             'disturbances': "di.disturbances",
             'soils': "so.soils",
+            'named_places': "np.places",
         }
         # identify minimal columns
         main_columns['minimal'] = {alias:col for alias, col in
@@ -401,6 +402,17 @@ class PlotObservation(Operator):
                 FROM soilobs
                 WHERE observation_id = ob.observation_id
             ) AS so ON true
+            LEFT JOIN LATERAL (
+              SELECT JSON_AGG(JSON_BUILD_OBJECT(
+                      'system', placesystem,
+                      'name', placename,
+                      'description', placedescription,
+                      'code', placecode)) AS places
+                FROM plot pl
+                JOIN place USING (plot_id)
+                JOIN namedplace USING (namedplace_id)
+                WHERE plot_id = ob.plot_id
+            ) AS np ON true
             """
         order_by_sql = {}
         order_by_sql['default'] = f"""\


### PR DESCRIPTION
### What

This PR enhances plot observation `GET` endpoints by returning a new `named_places` field with a nested array of locations (if any exist) associated with the plot observation. These are returned only when `detail=full&with_nested=true`.

### Why

So that clients can get all named places associated with plot observation.

### How

Updated relevant SQL code snippets in the PlotObservation operator.

### Testing & documentation

* Manually validated API responses with a few records with/without named places (see Demo section below)
* Locally updated the vegbankr API integration/E2E tests to expect the new field, and verified that they pass
* Updated the OAS document

### Demo

```sh
http GET 'http://127.0.0.1/plot-observations/ob.96868?with_nested=true' \
    | jq ".data[] | {named_places}" 
```
```json
{
  "named_places": [
    {
      "code": "n-us-va",
      "description": null,
      "name": "Virginia",
      "system": "region|state|province"
    },
    {
      "code": "51049",
      "description": "Virginia",
      "name": "Cumberland",
      "system": "county"
    }
  ]
}
```
```sh
$ http GET 'http://127.0.0.1/plot-observations/ob.27964?with_nested=true' \
    | jq ".data[] | {named_places}"
{
  "named_places": null
}
```