### PR TITLE
Feature-237: Populate `identifiers` table with `userdataset` accession codes and vb codes

### DIFF
--- a/helm/db/migrations/V2.5__backfill_userdataset_acc_vb_codes.sql
+++ b/helm/db/migrations/V2.5__backfill_userdataset_acc_vb_codes.sql
@@ -3,17 +3,13 @@
 -- re-execute procedures to populate 'identifiers' table
 ----------------------------------------------------------------------------
 
-BEGIN;
-
 -- Add missing mapping rows
 INSERT INTO identifiers_source_map (source_table, table_code, pk_column, id_type)
 VALUES
-  ('userdataset', 'ds', 'userdataset_id', 'accession_code'),
-  ('userdataset', 'ds', 'userdataset_id', 'vb_code')
+  ('userdataset', 'ud', 'userdataset_id', 'accession_code'),
+  ('userdataset', 'ud', 'userdataset_id', 'vb_code')
 ON CONFLICT DO NOTHING;
 
 -- Call procedures (which can handle conflicts)
 CALL populate_acc_code_identifiers();
 CALL populate_vb_code_identifiers();
-
-COMMIT;


### PR DESCRIPTION
**Summary of Changes:**
- Added migration file to insert `userdataset` table information into the `identifiers_source_map` table
    - Then call procedures to re-populate the `identifiers` table with `userdataset` table information

https://github.com/NCEAS/vegbank2/issues/237