### PR TITLE
Add functional upload endpoint for Community Classifications

### DIFF
--- a/queries/community_classification/comm_class/create_comm_class_temp_table.sql
+++ b/queries/community_classification/comm_class/create_comm_class_temp_table.sql
@@ -1,0 +1,14 @@
+CREATE TEMPORARY TABLE comm_class_temp(
+    user_ob_code TEXT,
+    user_cl_code TEXT NOT NULL,
+    classstartdate TIMESTAMP WITH TIME ZONE,
+    classstopdate TIMESTAMP WITH TIME ZONE,
+    inspection BOOLEAN,
+    tableanalysis BOOLEAN,
+    multivariateanalysis BOOLEAN,
+    expertsystem TEXT,
+    vb_rf_code TEXT,
+    user_rf_code TEXT,
+    classnotes TEXT,
+    vb_ob_code TEXT NOT NULL
+);

--- a/queries/community_classification/comm_class/insert_comm_class.sql
+++ b/queries/community_classification/comm_class/insert_comm_class.sql
@@ -1,0 +1,30 @@
+MERGE INTO commclass dst
+USING comm_class_temp src
+ON FALSE
+WHEN MATCHED THEN DO NOTHING
+WHEN NOT MATCHED THEN
+  INSERT (
+    observation_id,
+    classstartdate,
+    classstopdate,
+    inspection,
+    tableanalysis,
+    multivariateanalysis,
+    expertsystem,
+    classpublication_id,
+    classnotes
+  ) VALUES (
+    CAST(SUBSTRING(src.vb_ob_code, 4) AS INT),
+    src.classstartdate,
+    src.classstopdate,
+    src.inspection,
+    src.tableanalysis,
+    src.multivariateanalysis,
+    src.expertsystem,
+    CAST(SUBSTRING(src.vb_rf_code, 4) AS INT),
+    src.classnotes
+  )
+RETURNING merge_action(),
+          src.user_cl_code,
+          dst.commclass_id,
+          'cl.' || dst.commclass_id AS vb_cl_code;

--- a/queries/community_classification/comm_class/insert_comm_class_to_temp_table.sql
+++ b/queries/community_classification/comm_class/insert_comm_class_to_temp_table.sql
@@ -1,0 +1,18 @@
+-- Ordering of input parameters is handled via list order in table_defs_config.py
+INSERT INTO comm_class_temp
+    (
+        user_ob_code,
+        user_cl_code,
+        classstartdate,
+        classstopdate,
+        inspection,
+        tableanalysis,
+        multivariateanalysis,
+        expertsystem,
+        vb_rf_code,
+        user_rf_code,
+        classnotes,
+        vb_ob_code
+    )
+VALUES (%s, %s, %s, %s, %s, %s,
+        %s, %s, %s, %s, %s, %s);

--- a/queries/community_classification/comm_class/validate_comm_class.sql
+++ b/queries/community_classification/comm_class/validate_comm_class.sql
@@ -1,0 +1,12 @@
+-- Validate ob codes
+SELECT comm_class_temp.vb_ob_code
+  FROM comm_class_temp LEFT JOIN observation
+    ON comm_class_temp.vb_ob_code = 'ob.' || observation.observation_id
+  WHERE observation.observation_id IS NULL;
+
+-- Validate reference codes
+SELECT comm_class_temp.vb_rf_code
+  FROM comm_class_temp LEFT JOIN reference
+    ON comm_class_temp.vb_rf_code = 'rf.' || reference.reference_id
+  WHERE reference.reference_id IS NULL
+    AND comm_class_temp.vb_rf_code IS NOT NULL;

--- a/queries/community_classification/comm_interp/create_comm_interp_temp_table.sql
+++ b/queries/community_classification/comm_interp/create_comm_interp_temp_table.sql
@@ -1,0 +1,13 @@
+CREATE TEMPORARY TABLE comm_interp_temp(
+    user_cl_code TEXT,
+    vb_cc_code TEXT NOT NULL,
+    classfit CHARACTER VARYING(50),
+    classconfidence CHARACTER VARYING(15),
+    vb_rf_code TEXT,
+    user_rf_code TEXT,
+    notes TEXT,
+    type BOOLEAN,
+    nomenclaturaltype BOOLEAN,
+    user_ci_code TEXT NOT NULL,
+    vb_cl_code TEXT NOT NULL
+);

--- a/queries/community_classification/comm_interp/insert_comm_interp.sql
+++ b/queries/community_classification/comm_interp/insert_comm_interp.sql
@@ -1,0 +1,28 @@
+MERGE INTO comminterpretation dst
+USING comm_interp_temp src
+ON FALSE
+WHEN MATCHED THEN DO NOTHING
+WHEN NOT MATCHED THEN
+  INSERT (
+    commclass_id,
+    commconcept_id,
+    classfit,
+    classconfidence,
+    commauthority_id,
+    notes,
+    type,
+    nomenclaturaltype
+  ) VALUES (
+    CAST(SUBSTRING(src.vb_cl_code, 4) AS INT),
+    CAST(SUBSTRING(src.vb_cc_code, 4) AS INT),
+    src.classfit,
+    src.classconfidence,
+    CAST(SUBSTRING(src.vb_rf_code, 4) AS INT),
+    src.notes,
+    src.type,
+    src.nomenclaturaltype
+  )
+RETURNING merge_action(),
+          src.user_ci_code as user_ci_code,
+          dst.comminterpretation_id,
+          'ci.' || dst.comminterpretation_id AS vb_ci_code;

--- a/queries/community_classification/comm_interp/insert_comm_interp_to_temp_table.sql
+++ b/queries/community_classification/comm_interp/insert_comm_interp_to_temp_table.sql
@@ -1,0 +1,17 @@
+-- Ordering of input parameters is handled via list order in table_defs_config.py
+INSERT INTO comm_interp_temp
+    (
+        user_cl_code,
+        vb_cc_code,
+        classfit,
+        classconfidence,
+        vb_rf_code,
+        user_rf_code,
+        notes,
+        type,
+        nomenclaturaltype,
+        user_ci_code,
+        vb_cl_code
+    )
+VALUES (%s, %s, %s, %s, %s,
+        %s, %s, %s, %s, %s, %s);

--- a/queries/community_classification/comm_interp/validate_comm_interp.sql
+++ b/queries/community_classification/comm_interp/validate_comm_interp.sql
@@ -1,0 +1,18 @@
+-- Validate comm class codes
+SELECT comm_interp_temp.vb_cl_code
+  FROM comm_interp_temp LEFT JOIN commclass
+    ON comm_interp_temp.vb_cl_code = 'cl.' || commclass.commclass_id
+  WHERE commclass.commclass_id IS NULL;
+
+-- Validate comm concept codes
+SELECT comm_interp_temp.vb_cc_code
+  FROM comm_interp_temp LEFT JOIN commconcept
+    ON comm_interp_temp.vb_cc_code = 'cc.' || commconcept.commconcept_id
+  WHERE commconcept.commconcept_id IS NULL;
+
+-- Validate reference codes
+SELECT comm_interp_temp.vb_rf_code
+  FROM comm_interp_temp LEFT JOIN reference
+    ON comm_interp_temp.vb_rf_code = 'rf.' || reference.reference_id
+  WHERE reference.reference_id IS NULL
+    AND comm_interp_temp.vb_rf_code IS NOT NULL;

--- a/vegbank/operators/table_defs_config.py
+++ b/vegbank/operators/table_defs_config.py
@@ -189,6 +189,37 @@ taxon_observation = [
 ]
 
 # system added:
+# - 'vb_ob_code'
+comm_class = [
+    'user_ob_code',
+    'user_cl_code',
+    'class_start_date',
+    'class_stop_date',
+    'inspection',
+    'table_analysis',
+    'multivariate_analysis',
+    'expert_system',
+    'vb_comm_class_rf_code',
+    'user_comm_class_rf_code',
+    'class_notes'
+]
+
+# system added:
+# - 'user_ci_code'
+# - 'vb_cl_code'
+comm_interp = [
+    'user_cl_code',
+    'vb_cc_code',
+    'class_fit',
+    'class_confidence',
+    'vb_authority_rf_code',
+    'user_authority_rf_code',
+    'interp_notes',
+    'type',
+    'nomenclaturaltype'
+]
+
+# system added:
 # - 'user_cn_code'
 comm_name = [
     'name'

--- a/vegbank/vegbankapi.py
+++ b/vegbank/vegbankapi.py
@@ -418,8 +418,7 @@ def community_classifications(vb_code):
     """
     community_classification_operator = CommunityClassification(params)
     if request.method == 'POST':
-        return jsonify_error_message(
-            "POST method is not supported for community_classifications."), 405
+        return community_classification_operator.upload_all(request)
     elif request.method == 'GET':
         return community_classification_operator.get_vegbank_resources(request,
                                                                        vb_code)


### PR DESCRIPTION
### What

This PR adds a new `POST` endpoint and corresponding functionality for uploading and inserting Community Classifications into VegBank, including:
- **Community classification** details, including references to plot observations
- Related **Community interpretation** details, which include references to community concepts

Although this PR introduces bulk **community classification** upload via a standalone endpoint (requiring all records to refer to existing plot observations in VegBank), the underlying functionality can be reused by the bulk **plot observation** upload endpoint to classify new plot observations (not yet in VegBank) at the time of their upload. This latter integration will be added in a subsequent PR.

### Why

So that users/clients can upload new community classifications/interpretations of existing VegBank plot observations, in bulk.

### More details

Note that community "classification" here is actually a mashup of classification and interpretation, which are modeled using separate (but related) backend database tables.

In VegBank, although most classification records have one corresponding interpretation record, technically a single classification can contain multiple interpretations; we support this via the uploader by treating multiple rows having the same classification record identifier (column `user_cl_code`) as distinct interpretation records belonging to that classification, provided they each refer to a different community concept (column `vb_cc_code`).

We do not support:
* Uploading multiple interpretations pointing to the same concept, under the same classification
* Uploading interpretations that refer to classifications already in VegBank

### How
- A new method in the `CommunityClassification` operator class for preprocessing and performing inserts of data from the uploaded community_classifications dataset into the database `commclass` and `comminterpretation` tables, with correct internal foreign keys pointing to the corresponding plot observations, community concepts, and (optionally) references.
- Added SQL files for the component load processes defined above, with separate code for each of:
  - creation of a temp table
  - insert of data into the temp table
  - validation of data in the temp table
  - insert of data from the temp table into the destination table
- Added a new `upload_all` orchestrator method that takes the incoming request, reads in the data from the uploaded file (currently just the classifications data, but continue reading!), and sequentially loads everything with the necessary intermediate processing. This method will be extended in a future PR to accommodate upload of new **references** to be uploaded along with the classifications, such that they can be inserted first and then linked to the new classification records.
- Enabled the `POST /community-concepts` route for accepting community classification upload requests.

### Testing

Successfully tested some trivial sample classification data uploads. See demo below.

### Demo

Example of uploading 3 interpretations under 2 classifications. This uses a locally enhanced version of the `vegbankr` package capable of turning R data frames into Parquet files and sending them to the API.  

```r
cl_responses <- vb_upload("community-classifications",
  community_classifications = data.frame(
    user_cl_code = c("my_cl_1", "my_cl_1", "my_cl_2"),
    vb_ob_code = "ob.28256",
    vb_authority_rf_code = "rf.33",
    vb_cc_code = c("cc.53473", "cc.53474", "cc.53475")
    ), dry_run=TRUE)
# dry run - rolling back transaction.
# -> inserted 3 ci record(s)
# -> inserted 2 cl record(s)
# $ci
#     action      user_ci_code vb_ci_code
# 1 inserted my_cl_1->cc.53473  ci.114136
# 2 inserted my_cl_1->cc.53474  ci.114137
# 3 inserted my_cl_2->cc.53475  ci.114138
# 
# $cl
#     action user_cl_code vb_cl_code
# 1 inserted      my_cl_1  cl.167447
# 2 inserted      my_cl_2  cl.167448
```