### PR TITLE
Add community classification into plot observation upload

### DIFF
--- a/vegbank/operators/PlotObservation.py
+++ b/vegbank/operators/PlotObservation.py
@@ -737,15 +737,18 @@ class PlotObservation(Operator):
                     # check for it because it's not required in the context of
                     # standalone comm class uploads
                     data['cl']['user_ob_code'] = data['cl']['user_ob_code'].astype(str)
+                    # ... merge in newly created vb_ob_codes
                     data['cl'] = merge_vb_codes(
                         pls['resources']['ob'], data['cl'],
                         {'user_ob_code': 'user_ob_code',
                          'vb_ob_code': 'vb_ob_code'})
                     if data['rf'] is not None:
+                        # ... merge in newly created comm class vb_rf_codes
                         data['cl'] = merge_vb_codes(
                             rfs['resources']['rf'], data['cl'],
                             {'user_rf_code': 'user_comm_class_rf_code',
                              'vb_rf_code': 'vb_comm_class_rf_code'})
+                        # ... merge in newly created interp authority vb_rf_codes
                         data['cl'] = merge_vb_codes(
                             rfs['resources']['rf'], data['cl'],
                             {'user_rf_code': 'user_authority_rf_code',


### PR DESCRIPTION
### What

This PR integrates community classification/interpretation into the `POST /plot-observations` endpoint, allowing clients to include a `community_classifications` Parquet file that contains new classification/interpretation records linking plot observations (that are also being uploaded to the endpoint) with community concepts (that are already in VegBank).

### Why

So that users can submit community classifications/interpretations along with their plot observations.

### How

Added the requisite logic into the PlotObservation `upload_all()` method, conditional on whether the relevant data file is contained in the request.

### Testing

Tested a simple case locally using `vegbankr`:

```r
> plot_observations_df[1:4]
#   user_pl_code user_ob_code vb_pj_code author_plot_code
# 1      my_pl_1      my_ob_1     pj.339          my_pl_1

> community_classifications_df
#   user_cl_code user_ob_code vb_cc_code class_fit
# 1      my_cl_1      my_ob_1   cc.53473      poor
# 2      my_cl_1      my_ob_1   cc.53474     great
# 3      my_cl_2      my_ob_1   cc.53475     great

> ob_with_cl_responses <- vb_upload("plot-observations",
      plot_observations = plot_observations_df,
      community_classifications = community_classifications_df,
      dry_run=TRUE)
# dry run, transaction was rolled back
# -> inserted 3 ci record(s)
# -> inserted 2 cl record(s)
# -> inserted 1 ob record(s)
# -> inserted 1 pl record(s)
# $ci
#     action      user_ci_code vb_ci_code
# 1 inserted my_cl_1->cc.53473  ci.114166
# 2 inserted my_cl_1->cc.53474  ci.114167
# 3 inserted my_cl_2->cc.53475  ci.114168
# 
# $cl
#     action user_cl_code vb_cl_code
# 1 inserted      my_cl_1  cl.167473
# 2 inserted      my_cl_2  cl.167474
# 
# $ob
#     action user_ob_code vb_ob_code
# 1 inserted      my_ob_1  ob.225896
# 
# $pl
#     action user_pl_code vb_pl_code
# 1 inserted      my_pl_1  pl.228199
```