### PR TITLE
Add endpoint to get all plot observations for a user dataset

### DIFF
--- a/api/openapi.yml
+++ b/api/openapi.yml
@@ -292,6 +292,38 @@ paths:
           $ref: "#/components/responses/PlotObservations"
         '400':
           $ref: "#/components/responses/InvalidParameters"
+  /user-datasets/{ds_code}/plot-observations:
+    get:
+      tags:
+        - Plot observations
+      operationId: get-ob-by-ds
+      summary: Get all plot observations included in a user dataset
+      description: >
+        Retrieve a paginated and sorted collection of all plot
+        observations associated with the specified user dataset (using
+        its `ds_code`), or a subset thereof based on a specified
+        `search` query.
+      parameters:
+        - name: ds_code
+          in: path
+          required: true
+          schema:
+            type: string
+          example: "ds.1"
+        - $ref: '#/components/parameters/search'
+        - $ref: '#/components/parameters/detail_ob'
+        - $ref: '#/components/parameters/with_nested'
+        - $ref: '#/components/parameters/sort_ob'
+        - $ref: '#/components/parameters/limit'
+        - $ref: '#/components/parameters/offset'
+        - $ref: '#/components/parameters/create_parquet'
+        - $ref: '#/components/parameters/num_taxa_ob'
+        - $ref: '#/components/parameters/num_comms_ob'
+      responses:
+        '200':
+          $ref: "#/components/responses/PlotObservations"
+        '400':
+          $ref: "#/components/responses/InvalidParameters"
   /plot-observations:
     get:
       tags:

--- a/vegbank/operators/PlotObservation.py
+++ b/vegbank/operators/PlotObservation.py
@@ -455,6 +455,19 @@ class PlotObservation(Operator):
                     'sql': "ob.observation_id = %s",
                     'params': ['vb_id']
                 },
+                'ds': {
+                    'sql': """\
+                        EXISTS (
+                            SELECT itemrecord
+                              FROM userdataset ud
+                              JOIN userdatasetitem udi USING (userdataset_id)
+                              WHERE ud.datasetsharing = 'public'
+                                AND udi.itemtable = 'observation'
+                                AND ob.observation_id = udi.itemrecord
+                                AND ud.userdataset_id = %s)
+                        """,
+                    'params': ['vb_id']
+                },
                 'cc': {
                     'sql': """\
                         EXISTS (

--- a/vegbank/vegbankapi.py
+++ b/vegbank/vegbankapi.py
@@ -69,6 +69,7 @@ def welcome_page():
 @app.route("/community-concepts/<vb_code>/plot-observations", methods=['GET'])
 @app.route("/cover-methods/<vb_code>/plot-observations", methods=['GET'])
 @app.route("/stratum-methods/<vb_code>/plot-observations", methods=['GET'])
+@app.route("/user-datasets/<vb_code>/plot-observations", methods=['GET'])
 def plot_observations(vb_code):
     """
     Retrieve either an individual plot observation or a collection, or


### PR DESCRIPTION
### What

This PR adds a new cross-resource `GET` endpoint for retrieving all plot observations for a given user dataset, using the vb_code identifying the user dataset (e.g., `ds.123`).

Note that this endpoint by itself doesn't provide a way to get the plot observations using an accession code, DOI, or other any form of external citation.

### Why

So that users can can get plot observations associated with a given user dataset!

### How

- Added a new route `GET /user-datasets/ds.123/plot-observations`
- Added

### Testing and documentation
- Manually tested against a local instance of the DB and API
- Updated the OAS file with relevant endpoint documentation

### Demo

Use existing endpoint to show a dataset with 8 associated plot observations
```sh
$ http GET 'http://127.0.0.1/user-datasets/ds.199635' \
    | jq ".data[] | {obs_count}"
```
```json
{
  "obs_count": 8
}
```

Show that the new endpoint yields the expected number of plot observations for this dataset
```sh
$ http GET 'http://127.0.0.1/user-datasets/ds.199635/plot-observations?count'
```
```json
{
    "count": 8
}
```

Use the new endpoint to retrieve the first 2 such plot observations associated with this dataset

```sh
$ http GET 'http://127.0.0.1/user-datasets/ds.199635/plot-observations?detail=geo&limit=2'
```
```json
{
    "count": 8,
    "data": [
        {
            "author_obs_code": "002-01-0042",
            "latitude": 34.676394168,
            "longitude": -79.228581147,
            "ob_code": "ob.79046"
        },
        {
            "author_obs_code": "003-02-0082",
            "latitude": 34.704708132,
            "longitude": -78.619778039,
            "ob_code": "ob.79207"
        }
    ]
}
```