### PR TITLE
Fix plot observation upload when all plots already exist

### DIFF
--- a/vegbank/operators/PlotObservation.py
+++ b/vegbank/operators/PlotObservation.py
@@ -609,6 +609,7 @@ class PlotObservation(Operator):
             raise ValueError(validation['error']) 
 
         df['user_pl_code'] = df['user_pl_code'].astype(str)
+        to_return = None
         if not new_plots_df.empty:
             plot_codes = super().upload_to_table("plot", 'pl', table_defs_config.plot, 'plot_id', new_plots_df, True, conn)
             
@@ -618,20 +619,12 @@ class PlotObservation(Operator):
             df = df.merge(pl_codes_df, on='user_pl_code', how='left')
             df['vb_pl_code'] = df['vb_pl_code_x'].combine_first(df['vb_pl_code_y'])
             df.drop(columns=['vb_pl_code_y'], inplace=True)
+            to_return = combine_json_return(to_return, plot_codes)
 
         df['user_ob_code'] = df['user_ob_code'].astype(str)
         observation_codes = super().upload_to_table("observation", 'ob', table_defs_config.observation, 'observation_id', df, True, conn)
+        to_return = combine_json_return(to_return, observation_codes)
 
-        to_return = {
-            'resources':{
-                'pl': plot_codes['resources']['pl'],
-                'ob': observation_codes['resources']['ob']
-            },
-            'counts':{
-                'pl': plot_codes['counts']['pl'],
-                'ob': observation_codes['counts']['ob']
-            }
-        }
         return to_return
     
     def upload_all(self, request):


### PR DESCRIPTION
### What

This PR fixes an error occurring when the plot_observations upload table exclusively refers to existing VegBank plots, rather than uploading any new plots -- i.e., when the data contains a `vb_pl_code` column but no `user_pl_code` column.

### What was broken

See below for the error from the perspective of the R client. Notice that the table only contains `vb_pl_code` referring to an existing VegBank plot, no `user_pl_code`.

```r
> plot_observations_vb_plot <- data.frame(
  user_ob_code = "jr_ob.1",
  author_obs_code = "jr-obs-1",
  author_plot_code = "jr-pl-1",
  vb_pl_code = "pl.3008",
  vb_pj_code = "pj.340",
  real_latitude = 34.4203,
  real_longitude =  119.6989,
  latitude = 34.4203,
  longitude =  119.6989,
  confidentiality_status = 0
)
> vb_upload_plot_observations(plot_observations_vb_plot, dry_run = TRUE)
Error in `req_perform()` at vegbankr-clean/R/utils.R:133:5:
! HTTP 500 Internal Server Error.
ℹ cannot access local variable 'plot_codes' where it is not associated with a value
Run `rlang::last_trace()` to see where the error occurred.
```

Python console output:
```py
Traceback (most recent call last):
  File "/dev/vegbank2-clean/vegbank/operators/PlotObservation.py", line 741, in upload_all
    pls = PlotObservation(self.params).upload_plot_observations(data['pl'], conn)
  File "/dev/vegbank2-clean/vegbank/operators/PlotObservation.py", line 614, in upload_plot_observations
    'pl': plot_codes['resources']['pl'],
          ^^^^^^^^^^
UnboundLocalError: cannot access local variable 'plot_codes' where it is not associated with a value
```

This happens because `plot_codes` is first created inside an `if` block that we don't enter when there are no new plots to create.

### What fixed it

Use the same pattern we use in `upload_all()` code flow, where by we start with an empty (`None`) return object and then built it up as we go.

Now in R:
```r
> vb_upload_plot_observations(plot_observations_vb_plot, dry_run = TRUE)
dry run, transaction was rolled back
-> inserted 1 ob record(s)
$ob
    action user_ob_code vb_ob_code
1 inserted      jr_ob.1  ob.228193
```

... and for good measure, confirmation that the endpoint still works when we provide new plots:

```r
> plot_observations_user_plot <- data.frame(
  user_ob_code = "jr_ob.1",
  author_obs_code = "jr-obs-1",
  author_plot_code = "jr-pl-1",
  user_pl_code = "jr_ob.1",
  vb_pj_code = "pj.340",
  real_latitude = 34.4203,
  real_longitude =  119.6989,
  latitude = 34.4203,
  longitude =  119.6989,
  confidentiality_status = 0
)
> vb_upload_plot_observations(plot_observations_user_plot, dry_run = TRUE)
dry run, transaction was rolled back
-> inserted 1 ob record(s)
-> inserted 1 pl record(s)
$ob
    action user_ob_code vb_ob_code
1 inserted      jr_ob.1  ob.228194

$pl
    action user_pl_code vb_pl_code
1 inserted      jr_ob.1  pl.230481
```
:sparkles: