### PR TITLE
Return records with null embargo

### DIFF
--- a/vegbank/operators/CommunityClassification.py
+++ b/vegbank/operators/CommunityClassification.py
@@ -167,7 +167,7 @@ class CommunityClassification(Operator):
             'conditions': {
                 'always': {
                     'sql': [
-                        "emb_commclass < 6",
+                        "(emb_commclass < 6 OR emb_commclass IS NULL)",
                     ],
                     'params': []
                 },

--- a/vegbank/operators/CommunityInterpretation.py
+++ b/vegbank/operators/CommunityInterpretation.py
@@ -122,7 +122,7 @@ class CommunityInterpretation(Operator):
             'conditions': {
                 'always': {
                     'sql': [
-                        "emb_comminterpretation < 6",
+                        "(emb_comminterpretation < 6 OR emb_comminterpretation IS NULL)",
                     ],
                     'params': []
                 },

--- a/vegbank/operators/PlotObservation.py
+++ b/vegbank/operators/PlotObservation.py
@@ -441,7 +441,7 @@ class PlotObservation(Operator):
             'conditions': {
                 'always': {
                     'sql': [
-                        "emb_observation < 6",
+                        "(emb_observation < 6 OR emb_observation IS NULL)",
                     ],
                     'params': []
                 },

--- a/vegbank/operators/TaxonInterpretation.py
+++ b/vegbank/operators/TaxonInterpretation.py
@@ -102,7 +102,7 @@ class TaxonInterpretation(Operator):
             'conditions': {
                 'always': {
                     'sql': [
-                        "emb_taxoninterpretation < 6",
+                        "(emb_taxoninterpretation < 6 OR emb_taxoninterpretation IS NULL)",
                     ],
                     'params': []
                 },

--- a/vegbank/operators/TaxonObservation.py
+++ b/vegbank/operators/TaxonObservation.py
@@ -124,7 +124,7 @@ class TaxonObservation(Operator):
             'conditions': {
                 'always': {
                     'sql': [
-                        "emb_taxonobservation < 6",
+                        "(emb_taxonobservation < 6 OR emb_taxonobservation IS NULL)",
                     ],
                     'params': []
                 },


### PR DESCRIPTION
### What

This PR makes a quick change to return records with null embargo status.

### Why

So that records that have been uploaded via the API, which doesn't currently set an embargo status, are returned by API.

### How

Tweaked all the relevant SQL `WHERE` clauses.

### Testing

Manually tested by querying a local DB (having null embargo records) before and after the code change, and verifying that the expected records are now returned.