### PR TITLE
Performance - Removing slow new_identifiers lines

### DIFF
--- a/vegbank/operators/Party.py
+++ b/vegbank/operators/Party.py
@@ -227,7 +227,7 @@ class Party(Operator):
         new_ob_contributors = {'counts':{'cr':{'inserted':0}}, 'resources':{'cr':[]}}
         new_pj_contributors = {'counts':{'cr':{'inserted':0}}, 'resources':{'cr':[]}}
         new_cl_contributors = {'counts':{'cr':{'inserted':0}}, 'resources':{'cr':[]}}
-        print(ob_contributor_df)
+        
         if ob_contributor_df.empty is False:
             new_ob_contributors = super().upload_to_table("observation_contributor", 'cr', contributor_defs, 'observationcontributor_id', ob_contributor_df, False, conn, validate=True)
         if pj_contributor_df.empty is False:

--- a/vegbank/operators/TaxonObservation.py
+++ b/vegbank/operators/TaxonObservation.py
@@ -191,7 +191,6 @@ class TaxonObservation(Operator):
 
         df['user_tm_code'] = df['user_tm_code'].astype(str)
         taxon_importance_codes = super().upload_to_table("taxon_importance", 'tm', table_defs_config.taxon_importance, 'taxonimportance_id', df, True, conn)
-        print(taxon_importance_codes)
         to_return = {
             'resources':{
                 'to': taxon_observation_codes['resources']['to'],
@@ -257,7 +256,6 @@ class TaxonObservation(Operator):
         sl_df.replace({pd.NaT: None, np.nan: None}, inplace=True)
 
         sl_df.dropna(subset=['stem_code', 'stem_x_position', 'stem_y_position', 'stem_health'], inplace=True, how='all') #Drop rows where all stem location fields are null
-        print(sl_df)
         sl_df_no_code = sl_df[sl_df['user_sl_code'].isnull()] #Check if there are any rows with stem location data but no user_sl_code
         if not sl_df_no_code.empty:
             raise ValueError("All stem location records must have a user_sl_code when any stem location fields are provided.")

--- a/vegbank/operators/operator_parent_class.py
+++ b/vegbank/operators/operator_parent_class.py
@@ -630,7 +630,7 @@ class Operator:
                     - resources: pairs of user and vb codes for the new records
                     - counts: number of new records created
         """
-        print(f"DataFrame loaded with {len(df)} records.")
+        print(f"Uploading {insert_table_name} dataframe with {len(df)} records.")
         
         
         df.columns = df.columns.str.lower()
@@ -697,11 +697,6 @@ class Operator:
                 with open(sql_file_create_codes, "r") as file:
                     sql = file.read()
                 cur.executemany(sql, code_inputs, returning=True)
-                new_identifiers = cur.fetchall()
-                while cur.nextset():
-                    next_identifiers = cur.fetchall()
-                    if next_identifiers:
-                        new_identifiers = new_identifiers + next_identifiers
 
             vb_field_name = f'vb_{insert_table_code}_code'
             to_return = {}


### PR DESCRIPTION
### What
This PR removes a variable called new_identifiers from the upload_to_table method and the lines that fill it in as well. It also adjusts some print statements for more clear logging, which will be continued on a future PR. 

### Why
Because this variable isn't being used anywhere, and filling it in is very slow. When I originally wrote the section that creates codes, we didn't have the identifier table yet, and I wasn't sure if we were going to need to get something out of the create_codes sql or not. We already have the codes from the data insert, so we don't need to get them back again after this query. In addition, because this is an execute_many insert, getting all the returns out is very time consuming when the datasets get large. 

### How
Addition by subtraction, I've removed the lines. The variable is unused anywhere, so this doesn't affect anything. I also removed some print statements and tweaked the dataframe report in upload_to_table for better clarity when I'm reviewing the k8s logs. 

### Testing
I reran the bulk uploader with a number of different files, including the large Cal data files, and performance improved substantially, both locally and on the k8s cluster. 