### PR TITLE
Add GET endpoints for strata

### DIFF
--- a/api/openapi.yml
+++ b/api/openapi.yml
@@ -55,6 +55,8 @@ tags:
   description: Operations related to plant concepts
 - name: Taxon observations
   description: Operations related to taxon observations
+- name: Strata
+  description: Operations related to defined strata
 - name: Stem counts
   description: Operations related to stem counts
 - name: Taxon importances
@@ -1305,6 +1307,117 @@ paths:
         '400':
           $ref: "#/components/responses/InvalidParameters"
 
+  /strata/{sr_code}:
+    get:
+      tags:
+        - Strata
+      operationId: get-sr-by-id
+      summary: Get stratum
+      description: >
+        Retrieve a single stratum using its `sr_code`.
+      parameters:
+        - name: sr_code
+          in: path
+          required: true
+          schema:
+            type: string
+          example: "sr.1"
+        - $ref: '#/components/parameters/create_parquet'
+      responses:
+        '200':
+          $ref: "#/components/responses/Strata"
+        '400':
+          $ref: "#/components/responses/InvalidParameters"
+  /plot-observations/{ob_code}/strata:
+    get:
+      tags:
+        - Strata
+      operationId: get-sr-by-ob
+      summary: Get strata by ob
+      description: >
+        Retrieve a paginated collection of strata associated with the
+        specified plot observation (using its `ob_code`).
+      parameters:
+        - name: ob_code
+          in: path
+          required: true
+          schema:
+            type: string
+          example: "ob.1"
+        - $ref: '#/components/parameters/limit'
+        - $ref: '#/components/parameters/offset'
+        - $ref: '#/components/parameters/create_parquet'
+      responses:
+        '200':
+          $ref: "#/components/responses/Strata"
+        '400':
+          $ref: "#/components/responses/InvalidParameters"
+  /taxon-observations/{to_code}/strata:
+    get:
+      tags:
+        - Strata
+      operationId: get-sr-by-to
+      summary: Get strata by to
+      description: >
+        Retrieve a paginated collection of strata associated with the
+        specified taxon observation (using its `to_code`).
+      parameters:
+        - name: to_code
+          in: path
+          required: true
+          schema:
+            type: string
+          example: "to.1"
+        - $ref: '#/components/parameters/limit'
+        - $ref: '#/components/parameters/offset'
+        - $ref: '#/components/parameters/create_parquet'
+      responses:
+        '200':
+          $ref: "#/components/responses/Strata"
+        '400':
+          $ref: "#/components/responses/InvalidParameters"
+  /taxon-importances/{tm_code}/strata:
+    get:
+      tags:
+        - Strata
+      operationId: get-sr-by-tm
+      summary: Get strata by tm
+      description: >
+        Retrieve a paginated collection of strata associated with the
+        specified taxon importance (using its `tm_code`).
+      parameters:
+        - name: tm_code
+          in: path
+          required: true
+          schema:
+            type: string
+          example: "tm.1"
+        - $ref: '#/components/parameters/limit'
+        - $ref: '#/components/parameters/offset'
+        - $ref: '#/components/parameters/create_parquet'
+      responses:
+        '200':
+          $ref: "#/components/responses/Strata"
+        '400':
+          $ref: "#/components/responses/InvalidParameters"
+  /strata:
+    get:
+      tags:
+        - Strata
+      operationId: get-sr
+      summary: Get all strata
+      description: >
+        Retrieve a paginated collection of all strata recorded in VegBank.
+      parameters:
+        - $ref: '#/components/parameters/limit'
+        - $ref: '#/components/parameters/offset'
+        - $ref: '#/components/parameters/create_parquet'
+      responses:
+        '200':
+          $ref: "#/components/responses/Strata"
+        '400':
+          $ref: "#/components/responses/InvalidParameters"
+
   /taxon-interpretations/{ti_code}:
     get:
       tags:
@@ -2403,6 +2516,19 @@ components:
             format: binary
             description: Parquet file with same data as the JSON response.
 
+    Strata:
+      description: Matching stratum or strata
+      content:
+        application/json:
+          schema:
+            allOf:
+              - $ref: '#/components/schemas/stratum'
+        application/vnd.apache.parquet:
+          schema:
+            type: string
+            format: binary
+            description: Parquet file with same data as the JSON response.
+
     TaxonInterpretations:
       description: |
         Matching taxon interpretation(s), with fields based on parameters:
@@ -3395,7 +3521,7 @@ components:
                 example: "sr.1"
               stratum_name:
                 type: string
-                description: "Stratum name, or '-all-' if sr_code is null"
+                description: "Stratum name, or '<All>' if sr_code is null"
                 example: "herb"
               cover:
                 type: number
@@ -4566,6 +4692,60 @@ same as plot-observation taxon_inference_area"
     stem_count:
       $ref: '#/components/schemas/StemCount'
 
+    Stratum:
+      type: object
+      properties:
+        ob_code:
+          type: string
+          description: "VegBank plot observation identifier"
+          example: "ob.1"
+        sr_code:
+          type: string
+          description: "VegBank stratum identifier"
+          example: "sr.1"
+        name:
+          type: string
+          description: "Stratum name"
+          example: "Dwarf shrub"
+        height:
+          type: number
+          format: float
+          description: "#TODO"
+          example: 5
+        base:
+          type: number
+          format: float
+          description: "#TODO"
+          example: 2
+        cover:
+          type: number
+          format: float
+          description: "#TODO"
+          example: 45
+        description:
+          type: string
+          description: "Stratum description"
+          example: "Dwarf shrub"
+        sm_code:
+          type: string
+          description: "VegBank stratum method identifier"
+          example: "sm.1"
+        stratum_method_name:
+          type: string
+          description: "Name of the stratum method (e.g., Braun-Blanquet, TNC-ABI, NC Vegetation Survey #1, NC Vegetation Survey #2, etc.)"
+          example: "TurboVeg"
+        sy_code:
+          type: string
+          description: "VegBank stratum type identifier"
+          example: "sy.1"
+        stratum_type_name:
+          type: string
+          description: "Name associated with this stratum by the stratum method"
+          example: "Dwarf shrub"
+
+    stratum:
+      $ref: '#/components/schemas/Stratum'
+
     TaxonInterpMinimal:
       type: object
       properties:
@@ -5105,20 +5285,6 @@ same as plot-observation taxon_inference_area"
           type: string
         vb_code:
           type: string
-
-    stratum:
-      type: object
-      properties:
-        stratum_base:
-          type: number
-          format: float
-          description: "Average height of the bottom of the stratum in meters"
-          example: 0.1
-        stratum_height:
-          type: number
-          format: float
-          description: "Tallest part of the Stratum in meters."
-          example: 1.0
 
     disturbance_obs:
       type: object

--- a/vegbank/operators/Stratum.py
+++ b/vegbank/operators/Stratum.py
@@ -1,0 +1,122 @@
+import os
+from vegbank.operators import Operator
+
+
+class Stratum(Operator):
+    """
+    Defines operations related to the exchange of stratum records with VegBank
+
+    Stratum: Information about a stratum (i.e., a designated vertical layer or
+        other sub-component of a plot) defined for a given plot observation.
+        Taxon importance values and stem counts for observed taxa can be
+        measured and recorded separately for each stratum in a plot observation.
+
+    Inherits from the Operator parent class to utilize common default values and
+    methods.
+    """
+
+    def __init__(self, params):
+        super().__init__(params)
+        self.name = "stratum"
+        self.table_code = "sr"
+        self.QUERIES_FOLDER = os.path.join(self.QUERIES_FOLDER, self.name)
+
+    def configure_query(self, *args, **kwargs):
+        query_type = self.detail
+        base_columns = {'*': "*"}
+        main_columns = {}
+        main_columns['full'] = {
+            'ob_code': "'ob.' || sr.observation_id",
+            'sr_code': "'sr.' || sr.stratum_id",
+            'name': "sr.stratumname",
+            'height': "sr.stratumheight",
+            'base': "sr.stratumbase",
+            'cover': "sr.stratumcover",
+            'description': "sr.stratumdescription",
+            'sm_code': "'sm.' || sr.stratummethod_id",
+            'stratum_method_name': "sm.stratummethodname",
+            'sy_code': "'sy.' || sr.stratumtype_id",
+            'stratum_type_name': "sy.stratumname",
+        }
+        from_sql = {}
+        from_sql['full'] = """\
+            FROM sr
+            JOIN stratummethod sm USING (stratummethod_id)
+            JOIN stratumtype sy USING (stratumtype_id)
+            """
+        order_by_sql = """\
+            ORDER BY sr.stratum_id
+            """
+
+        self.query = {}
+        self.query['base'] = {
+            'alias': "sr",
+            'select': {
+                "always": {
+                    'columns': base_columns,
+                    'params': []
+                },
+            },
+            'from': {
+                'sql': "FROM stratum AS sr",
+                'params': []
+            },
+            'conditions': {
+                'always': {
+                    'sql': None,
+                    'params': []
+                },
+                "sr": {
+                    'sql': "sr.stratum_id = %s",
+                    'params': ['vb_id']
+                },
+                'ob': {
+                    'sql': "sr.observation_id = %s",
+                    'params': ['vb_id']
+                },
+                'to': {
+                    'sql': """\
+                        EXISTS (
+                            SELECT taxonimportance_id
+                             FROM taxonimportance tm
+                             JOIN taxonobservation txo USING (taxonobservation_id)
+                             WHERE sr.stratum_id = tm.stratum_id
+                               AND txo.taxonobservation_id = %s)
+                        """,
+                    'params': ['vb_id']
+                },
+                'tm': {
+                    'sql': """\
+                        EXISTS (
+                            SELECT taxonimportance_id
+                             FROM taxonimportance tm
+                             WHERE sr.stratum_id = tm.stratum_id
+                               AND tm.taxonimportance_id = %s)
+                        """,
+                    'params': ['vb_id']
+                },
+                'zip': {
+                    'sql': """\
+                        EXISTS (
+                            SELECT observation_id
+                             FROM bundle bb
+                             WHERE sr.observation_id = bb.observation_id)
+                        """,
+                    'params': []
+                },
+            },
+            'order_by': {
+                'sql': order_by_sql,
+                'params': []
+            },
+        }
+        self.query['select'] = {
+            "always": {
+                'columns': main_columns[query_type],
+                'params': []
+            },
+        }
+        self.query['from'] = {
+            'sql': from_sql[query_type],
+            'params': []
+        }

--- a/vegbank/operators/__init__.py
+++ b/vegbank/operators/__init__.py
@@ -11,6 +11,7 @@ from .Project import Project
 from .Reference import Reference
 from .Role import Role
 from .StemCount import StemCount
+from .Stratum import Stratum
 from .StratumMethod import StratumMethod
 from .TaxonImportance import TaxonImportance
 from .TaxonInterpretation import TaxonInterpretation
@@ -31,6 +32,7 @@ __all__ = [
     "Reference",
     "Role",
     "StemCount",
+    "Stratum",
     "StratumMethod",
     "TaxonImportance",
     "TaxonInterpretation",

--- a/vegbank/operators/operator_parent_class.py
+++ b/vegbank/operators/operator_parent_class.py
@@ -26,6 +26,7 @@ table_code_lookup = {
     'references': 'rf',
     'roles': 'ar',
     'stem-counts': 'sc',
+    'strata': 'sr',
     'stratum-methods': 'sm',
     'taxon-importances': 'tm',
     'taxon-interpretations': 'ti',

--- a/vegbank/vegbankapi.py
+++ b/vegbank/vegbankapi.py
@@ -24,6 +24,7 @@ from vegbank.operators import (
     Project,
     Role,
     StemCount,
+    Stratum,
     StratumMethod,
     Reference,
     UserDataset,
@@ -955,6 +956,62 @@ def stratum_methods(sm_code):
         return stratum_method_operator.upload_stratum_method(request, params)
     elif request.method == 'GET':
         return stratum_method_operator.get_vegbank_resources(request, sm_code)
+    else:
+        return jsonify_error_message("Method not allowed. Use GET or POST."), 405
+
+
+@app.route("/strata", defaults={'vb_code': None}, methods=['GET', 'POST'])
+@app.route("/strata/<vb_code>", methods=['GET'])
+@app.route("/plot-observations/<vb_code>/strata", methods=['GET'])
+@app.route("/taxon-observations/<vb_code>/strata", methods=['GET'])
+@app.route("/taxon-importances/<vb_code>/strata", methods=['GET'])
+def strata(vb_code):
+    """
+    Retrieve either an individual stratum or a collection of strata
+
+    This function handles HTTP requests for strata. It currently supports only
+    the GET method to retrieve records. If a POST request is made, it returns an
+    error message indicating that POST is not supported. For any other HTTP
+    method, it returns a 405 error.
+
+    GET: If a valid stratum code is provided (e.g., `sr.1`), returns the
+    corresponding record if it exists. If a valid code for a different supported
+    resource type is provided, returns the collection of stratum records
+    associated with that resource. If no vb_code is provided, returns the full
+    collection of stratum records. Collection responses may be further mediated
+    by pagination parameters and other filtering query parameters.
+
+    Parameters (for GET requests only):
+        vb_code (str or None): The unique identifier for the stratum
+            being retrieved. If None, retrieves all strata.
+
+    GET Query Parameters:
+        detail (str, optional): Level of detail for the response.
+            Only 'full' is defined for this method. Defaults to 'full'.
+        with_nested (str, optional): Include nested fields?
+            Only 'false' is defined for this method. Defaults to 'false'.
+        limit (int, optional): Maximum number of records to return.
+            Defaults to 1000.
+        offset (int, optional): Number of records to skip before starting
+            to return records. Defaults to 0.
+        create_parquet (str, optional): Whether to return data as Parquet
+            rather than JSON. Accepts 'true' or 'false' (case-insensitive).
+            Defaults to False.
+
+    Returns:
+        flask.Response: A Flask response object containing:
+            - 200: Successfully retrieved stratum/strata as JSON or
+                   Parquet (GET), or upload details as JSON (POST)
+            - 400: Invalid parameters
+            - 403: Uploads not allowed (POST only)
+            - 405: Unsupported HTTP method
+    """
+    stratum_operator = Stratum(params)
+    if request.method == 'POST':
+        return jsonify_error_message(
+            "POST method is not supported for strata."), 405
+    elif request.method == 'GET':
+        return stratum_operator.get_vegbank_resources(request, vb_code)
     else:
         return jsonify_error_message("Method not allowed. Use GET or POST."), 405
 


### PR DESCRIPTION
### What

This PR adds `GET` endpoints for strata (which are defined for a plot observation), allowing clients to get this data as:
1. A single record identified by its `sr_code`
2. The full paginated collection of stratum records
3. A sub-collection of stratum records associated with a specific plot observation, taxon observation, or taxon importance record, in each case identified by its appropriate vb code. Note that a query by taxon importance should return a single stratum record at most (i.e., a collection of size 1).

### Why

So that clients can directly access stratum details! Previously, we returned stratum information only implicitly as context for taxon importances, with no easy way to see all defined strata for entire plot observation, all defined strata in which the importance of a given taxon observation has been recorded, etc.

### How

- Added a new Stratum operator
- Add relevant new routes

### Testing and documentation
- Manually tested that the new endpoints work as expected
- Add complete API documentation of these new endpoints to the OpenAPI Spec doc
- Also locally uploaded `vegbankr` R package API integration and end-to-end tests for hitting the new endpoints, and confirmed that all tests pass

### Demo

##### Get one stratum record

```sh
$ http GET 'http://127.0.0.1:8080/strata/sr.17457'
```
```json
{
    "count": 1,
    "data": [
        {
            "base": null,
            "cover": 0.0,
            "description": null,
            "height": null,
            "name": "Short Shrub",
            "ob_code": "ob.2948",
            "sm_code": "sm.5",
            "sr_code": "sr.17457",
            "stratum_method_name": "National Park Service",
            "stratum_type_name": "Short Shrub",
            "sy_code": "sy.37"
        }
    ]
}
```

##### Get the full paginated collection of strata (limit 2)

```sh
$ http GET 'http://127.0.0.1:8080/strata?limit=2'
```
```json
{
    "count": 347097,
    "data": [
        {
            "base": null,
            "cover": 0.0,
            "description": null,
            "height": null,
            "name": "Tall Shrub",
            "ob_code": "ob.2948",
            "sm_code": "sm.5",
            "sr_code": "sr.17456",
            "stratum_method_name": "National Park Service",
            "stratum_type_name": "Tall Shrub",
            "sy_code": "sy.36"
        },
        {
            "base": null,
            "cover": 0.0,
            "description": null,
            "height": null,
            "name": "Short Shrub",
            "ob_code": "ob.2948",
            "sm_code": "sm.5",
            "sr_code": "sr.17457",
            "stratum_method_name": "National Park Service",
            "stratum_type_name": "Short Shrub",
            "sy_code": "sy.37"
        }
    ]
}
```

##### Get stratum records for a given plot observation (limit 2)

```sh
$ http GET 'http://127.0.0.1:8080/plot-observations/ob.2948/strata?limit=2'
```
```json
{
    "count": 10,
    "data": [
        {
            "base": null,
            "cover": 0.0,
            "description": null,
            "height": null,
            "name": "Tall Shrub",
            "ob_code": "ob.2948",
            "sm_code": "sm.5",
            "sr_code": "sr.17456",
            "stratum_method_name": "National Park Service",
            "stratum_type_name": "Tall Shrub",
            "sy_code": "sy.36"
        },
        {
            "base": null,
            "cover": 0.0,
            "description": null,
            "height": null,
            "name": "Short Shrub",
            "ob_code": "ob.2948",
            "sm_code": "sm.5",
            "sr_code": "sr.17457",
            "stratum_method_name": "National Park Service",
            "stratum_type_name": "Short Shrub",
            "sy_code": "sy.37"
        }
    ]
}
```

##### Get strata associated with a given taxon observation

```sh
$ http GET 'http://127.0.0.1:8080/taxon-observations/to.68185/strata'
```
```json
{
    "count": 2,
    "data": [
        {
            "base": null,
            "cover": 20.0,
            "description": null,
            "height": 0.5,
            "name": "Herbaceous",
            "ob_code": "ob.3062",
            "sm_code": "sm.5",
            "sr_code": "sr.22371",
            "stratum_method_name": "National Park Service",
            "stratum_type_name": "Herbaceous",
            "sy_code": "sy.39"
        },
        {
            "base": 5.0,
            "cover": 10.0,
            "description": null,
            "height": 10.0,
            "name": "Canopy",
            "ob_code": "ob.3062",
            "sm_code": "sm.5",
            "sr_code": "sr.22374",
            "stratum_method_name": "National Park Service",
            "stratum_type_name": "Canopy",
            "sy_code": "sy.34"
        }
    ]
}
```

##### Get the stratum associated with a given taxon importance record

```sh
$ http GET 'http://127.0.0.1:8080/taxon-importances/tm.74081/strata'
```
```json
{
    "count": 1,
    "data": [
        {
            "base": 5.0,
            "cover": 10.0,
            "description": null,
            "height": 10.0,
            "name": "Canopy",
            "ob_code": "ob.3062",
            "sm_code": "sm.5",
            "sr_code": "sr.22374",
            "stratum_method_name": "National Park Service",
            "stratum_type_name": "Canopy",
            "sy_code": "sy.34"
        }
    ]
}
```