### PR TITLE
Add GET endpoints for named places

### DIFF
--- a/api/openapi.yml
+++ b/api/openapi.yml
@@ -73,6 +73,8 @@ tags:
   description: Operations related to projects
 - name: References
   description: Operations related to references
+- name: Named Places
+  description: Operations related to named places
 - name: User Datasets
   description: |
     Operations related to VegBank datasets. A dataset is an arbitrary
@@ -1219,7 +1221,7 @@ paths:
   /plot-observations/{ob_code}/stem-counts:
     get:
       tags:
-        - Taxon importances
+        - Stem counts
       operationId: get-sc-by-ob
       summary: Get stem counts by ob
       description: >
@@ -1243,7 +1245,7 @@ paths:
   /taxon-observations/{to_code}/stem-counts:
     get:
       tags:
-        - Taxon importances
+        - Stem counts
       operationId: get-sc-by-to
       summary: Get stem counts by to
       description: >
@@ -1267,7 +1269,7 @@ paths:
   /taxon-importances/{tm_code}/stem-counts:
     get:
       tags:
-        - Taxon importances
+        - Stem counts
       operationId: get-sc-by-tm
       summary: Get stem counts by tm
       description: >
@@ -1291,7 +1293,7 @@ paths:
   /stem-counts:
     get:
       tags:
-        - Taxon importances
+        - Stem counts
       operationId: get-sc
       summary: Get all stem counts
       description: >
@@ -2034,6 +2036,46 @@ paths:
         '500':
           $ref: "#/components/responses/InvalidDataUpload"
 
+  /named-places/{np_code}:
+    get:
+      tags:
+        - Named Places
+      operationId: get-np-by-id
+      summary: Get named place
+      description: >
+        Retrieve a single named place using its `np_code`.
+      parameters:
+        - name: np_code
+          in: path
+          required: true
+          schema:
+            type: string
+          example: "np.1"
+        - $ref: '#/components/parameters/create_parquet'
+      responses:
+        '200':
+          $ref: "#/components/responses/NamedPlaces"
+        '400':
+          $ref: "#/components/responses/InvalidParameters"
+  /named-places:
+    get:
+      tags:
+        - Named Places
+      operationId: get-np
+      summary: Get all named places
+      description: >
+        Retrieve a paginated collection of all named places
+        recorded in VegBank.
+      parameters:
+        - $ref: '#/components/parameters/limit'
+        - $ref: '#/components/parameters/offset'
+        - $ref: '#/components/parameters/create_parquet'
+      responses:
+        '200':
+          $ref: "#/components/responses/NamedPlaces"
+        '400':
+          $ref: "#/components/responses/InvalidParameters"
+
   /user-datasets/{ds_code}:
     get:
       tags:
@@ -2626,6 +2668,19 @@ components:
           schema:
             allOf:
               - $ref: '#/components/schemas/reference'
+        application/vnd.apache.parquet:
+          schema:
+            type: string
+            format: binary
+            description: Parquet file with same data as the JSON response.
+
+    NamedPlaces:
+      description: Matching named place(s)
+      content:
+        application/json:
+          schema:
+            allOf:
+              - $ref: '#/components/schemas/named_place'
         application/vnd.apache.parquet:
           schema:
             type: string
@@ -5218,6 +5273,45 @@ same as plot-observation taxon_inference_area"
     reference:
       $ref: '#/components/schemas/Reference'
 
+    NamedPlace:
+      type: object
+      properties:
+        np_code:
+          type: string
+          description: "VegBank named place identifier"
+          example: "np.1"
+        system:
+          type: string
+          description: "Name of the system of names. The system 'Geographic Name' is an open list, whereas the other systems are generally closed lists defined by a known system with an external authority (e.g., USGSQuad, Continent, Country, State, County, HUC, and Ecoregion)"
+          example: "county"
+        name:
+          type: string
+          description: "The name of a place in or at which a plot is located."
+          example: "Zion NP"
+        description:
+          type: string
+          description: "Description of a named place. For US county names, this field identifies the containing state."
+          example: "Zion National Park"
+        code:
+          type: string
+          description: "Optional code for location identification"
+          example: "ZION"
+        owner:
+          type: string
+          description: "Designated location owner"
+          example: "US NPS"
+        rf_label:
+          type: string
+          description: "Label for the observation reference"
+          example: "US NPS place names"
+        obs_count:
+          type: integer
+          description: "Number of plot observations associated with this named place"
+          example: 8
+
+    named_place:
+      $ref: '#/components/schemas/NamedPlace'
+
     UserDataset:
       type: object
       properties:
@@ -5270,21 +5364,6 @@ same as plot-observation taxon_inference_area"
     #Placeholder for upload schemas
     tbd:
       type: object
-
-    #TODO
-    named_place:
-      type: object
-      properties:
-        place_system:
-          type: string
-        place_name:
-          type: string
-        place_code:
-          type: string
-        reference:
-          type: string
-        vb_code:
-          type: string
 
     disturbance_obs:
       type: object

--- a/vegbank/operators/NamedPlace.py
+++ b/vegbank/operators/NamedPlace.py
@@ -1,0 +1,80 @@
+import os
+from vegbank.operators import Operator
+
+
+class NamedPlace(Operator):
+    """
+    Defines operations related to the exchange of named places with VegBank.
+
+    Named Place: A named place (geographic region, managed unit, etc) in which a
+        plot may be located.
+
+    Inherits from the Operator parent class to utilize common default values and
+    methods.
+    """
+
+    def __init__(self, params):
+        super().__init__(params)
+        self.name = "named_place"
+        self.table_code = "np"
+        self.QUERIES_FOLDER = os.path.join(self.QUERIES_FOLDER, self.name)
+
+    def configure_query(self, *args, **kwargs):
+        base_columns = {'*': "*"}
+        main_columns = {}
+        main_columns['full'] = {
+            'np_code': "'np.' || np.namedplace_id",
+            'system': "np.placesystem",
+            'name': "np.placename",
+            'description': "np.placedescription",
+            'code': "np.placecode",
+            'owner': "np.owner",
+            'rf_label': "rf.reference_id_transl",
+            'obs_count': "np.d_obscount",
+        }
+        from_sql = """\
+            FROM np
+            LEFT JOIN view_reference_transl AS rf USING (reference_id)
+            """
+        order_by_sql = """\
+            ORDER BY np.namedplace_id
+            """
+
+        self.query = {}
+        self.query['base'] = {
+            'alias': "np",
+            'select': {
+                "always": {
+                    'columns': base_columns,
+                    'params': []
+                },
+            },
+            'from': {
+                'sql': "FROM namedplace AS np",
+                'params': []
+            },
+            'conditions': {
+                'always': {
+                    'sql': None,
+                    'params': []
+                },
+                "np": {
+                    'sql': "np.namedplace_id = %s",
+                    'params': ['vb_id']
+                },
+            },
+            'order_by': {
+                'sql': order_by_sql,
+                'params': []
+            },
+        }
+        self.query['select'] = {
+            "always": {
+                'columns': main_columns[self.detail],
+                'params': []
+            },
+        }
+        self.query['from'] = {
+            'sql': from_sql,
+            'params': []
+        }

--- a/vegbank/operators/__init__.py
+++ b/vegbank/operators/__init__.py
@@ -4,6 +4,7 @@ from .CommunityClassification import CommunityClassification
 from .CommunityConcept import CommunityConcept
 from .CommunityInterpretation import CommunityInterpretation
 from .CoverMethod import CoverMethod
+from .NamedPlace import NamedPlace
 from .Party import Party
 from .PlantConcept import PlantConcept
 from .PlotObservation import PlotObservation
@@ -25,6 +26,7 @@ __all__ = [
     "CommunityConcept",
     "CommunityInterpretation",
     "CoverMethod",
+    "NamedPlace",
     "Party",
     "PlantConcept",
     "PlotObservation",

--- a/vegbank/operators/operator_parent_class.py
+++ b/vegbank/operators/operator_parent_class.py
@@ -19,6 +19,7 @@ table_code_lookup = {
     'community-concepts': 'cc',
     'community-interpretations': 'ci',
     'cover-methods': 'cm',
+    'named-places': 'np',
     'parties': 'py',
     'plant-concepts': 'pc',
     'plot-observations': 'ob',

--- a/vegbank/vegbankapi.py
+++ b/vegbank/vegbankapi.py
@@ -21,6 +21,7 @@ from vegbank.operators import (
     CommunityInterpretation,
     CommunityConcept,
     CoverMethod,
+    NamedPlace,
     Project,
     Role,
     StemCount,
@@ -270,7 +271,7 @@ def taxon_importances(vb_code):
     taxon_importance_operator = TaxonImportance(params)
     if request.method == 'POST':
         return jsonify_error_message(
-            "POST method is not supported for community_interpretations."), 405
+            "POST method is not supported for taxon-importances."), 405
     elif request.method == 'GET':
         return taxon_importance_operator.get_vegbank_resources(request, vb_code)
     else:
@@ -596,7 +597,7 @@ def community_interpretations(vb_code):
     community_interpretation_operator = CommunityInterpretation(params)
     if request.method == 'POST':
         return jsonify_error_message(
-            "POST method is not supported for community_interpretations."), 405
+            "POST method is not supported for community-interpretations."), 405
     elif request.method == 'GET':
         return community_interpretation_operator.get_vegbank_resources(request,
                                                                        vb_code)
@@ -1113,10 +1114,59 @@ def roles(ar_code):
     """
     role_operator = Role(params)
     if request.method == 'POST':
-        return jsonify_error_message(
-            "POST method is not supported for roles."), 405
+        return role_operator.upload_all(request)
     elif request.method == 'GET':
         return role_operator.get_vegbank_resources(request, ar_code)
+    else:
+        return jsonify_error_message("Method not allowed. Use GET or POST."), 405
+
+
+@app.route("/named-places", defaults={'vb_code': None}, methods=['GET', 'POST'])
+@app.route("/named-places/<vb_code>")
+def named_places(vb_code):
+    """
+    Retrieve either an individual named place record or a collection.
+
+    This function handles HTTP requests for named places. It currently supports
+    only the GET method to retrieve records. If a POST request is made, it
+    returns an error message indicating that POST is not supported. For any
+    other HTTP method, it returns a 405 error.
+
+    GET: If a valid named place code is provided (e.g., `np.1`), returns the
+    corresponding record if it exists. If a valid code for a different supported
+    resource type is provided, returns the collection of named place records
+    associated with that resource. If no vb_code is provided, returns the full
+    collection of named place records. Collection responses may be further
+    mediated by pagination parameters and other filtering query parameters.
+
+    Parameters:
+        vb_code (str or None): The unique identifier for the named place
+            being retrieved. If None, retrieves all named places.
+
+    GET Query Parameters:
+        detail (str, optional): Level of detail for the response.
+            Only 'full' is defined for this method. Defaults to 'full'.
+        limit (int, optional): Maximum number of records to return.
+            Defaults to 1000.
+        offset (int, optional): Number of records to skip before starting
+            to return records. Defaults to 0.
+        create_parquet (str, optional): Whether to return data as Parquet
+            rather than JSON. Accepts 'true' or 'false' (case-insensitive).
+            Defaults to False.
+
+    Returns:
+        flask.Response: A Flask response object containing:
+            - 200: Successfully retrieved named place(s) as JSON or
+                   Parquet (GET)
+            - 400: Invalid parameters
+            - 405: Unsupported HTTP method
+    """
+    named_place_operator = NamedPlace(params)
+    if request.method == 'POST':
+        return jsonify_error_message(
+            "POST method is not supported for named-places."), 405
+    elif request.method == 'GET':
+        return named_place_operator.get_vegbank_resources(request, vb_code)
     else:
         return jsonify_error_message("Method not allowed. Use GET or POST."), 405
 
@@ -1163,7 +1213,7 @@ def user_datasets(ds_code):
     user_dataset_operator = UserDataset(params)
     if request.method == 'POST':
         return jsonify_error_message(
-            "POST method is not supported for community_interpretations."), 405
+            "POST method is not supported for user-datasets."), 405
     elif request.method == 'GET':
         return user_dataset_operator.get_vegbank_resources(request, ds_code)
     else:


### PR DESCRIPTION
### What

This PR adds `GET` endpoints for named places, allowing clients to get this data as:
1. A single named place identified by its `np_code`
2. The full paginated collection of named places

It also sneaks in a few minor code comment and OpenAPI doc fixes.

### Why

So that clients can get the set of named places registered in VegBank, especially for associating with their own plot observations at upload time ... if we choose to support this.

Previously we only returned named place records associated with specific plot observations, as a nested array field in the plot observation responses.

### How

- Added a new NamedPlace operator
- Add relevant new routes

### Testing and documentation
- Manually tested that the new endpoints work as expected
- Add complete API documentation of these new endpoints to the OpenAPI Spec doc
- Also locally uploaded `vegbankr` R package API integration and end-to-end tests for hitting the new endpoints, and confirmed that all tests pass

### Demo

##### Get one named place record

```sh
$ http GET 'http://127.0.0.1:8080/named-places/np.61514'
```
```json
{
    "count": 1,
    "data": [
        {
            "code": "ZION",
            "description": null,
            "name": "Zion NP",
            "np_code": "np.61514",
            "obs_count": 0,
            "owner": "US NPS",
            "rf_label": null,
            "system": "Geographic Name"
        }
    ]
}
```

##### Get the full paginated collection of named places (limit 2)

```sh
$ http GET 'http://127.0.0.1:8080/named-places?limit=2'
```
```json
{
    "count": 64563,
    "data": [
        {
            "code": "f",
            "description": null,
            "name": "Africa",
            "np_code": "np.1",
            "obs_count": 0,
            "owner": null,
            "rf_label": "USLC place names",
            "system": "continent"
        },
        {
            "code": "fc",
            "description": null,
            "name": "Africa, Central",
            "np_code": "np.2",
            "obs_count": 0,
            "owner": null,
            "rf_label": "USLC place names",
            "system": "area|country|territory"
        }
    ]
}
```