### PR TITLE
Provide plant concept deactivation at upload time

### DIFF
--- a/src/vegbank/operators/PlantConcept.py
+++ b/src/vegbank/operators/PlantConcept.py
@@ -9,7 +9,8 @@ from vegbank.utilities import (
     validate_required_and_missing_fields,
     merge_vb_codes,
     combine_json_return,
-    jsonify_error_message
+    jsonify_error_message,
+    process_option_param,
 )
 from psycopg.rows import dict_row
 from psycopg import connect
@@ -38,6 +39,8 @@ class PlantConcept(Operator):
         self.queries_package = f"{self.queries_package}.{self.name}"
         self.nested_options = ("true", "false")
         self.sort_options = ["default", "plant_name", "obs_count"]
+        self.deactivation_options = ["none", "by_party", "by_party_below_order"]
+        self.default_deactivation = "none"
 
     def configure_query(self, *args, **kwargs):
         query_type = self.detail
@@ -362,7 +365,12 @@ class PlantConcept(Operator):
                         rf_actions['resources']['rf'], data['pc'],
                         {"user_rf_code": "user_status_rf_code",
                          "vb_rf_code": "vb_status_rf_code"})
-                pc_actions = self.upload_plant_concepts(data['pc'], conn)
+                what_to_deactivate = process_option_param('deactivation',
+                    request.args.get('deactivation', self.default_deactivation),
+                    self.deactivation_options)
+
+                pc_actions = self.upload_plant_concepts(
+                    data['pc'], conn, what_to_deactivate = what_to_deactivate)
                 to_return = combine_json_return(to_return, pc_actions)
 
                 # Prep & insert any new plant names
@@ -424,7 +432,7 @@ class PlantConcept(Operator):
                 f"an error occurred here during upload: {str(e)}"), 500
         return jsonify(to_return)
 
-    def upload_plant_concepts(self, df, conn):
+    def upload_plant_concepts(self, df, conn, what_to_deactivate = 'none'):
         """
         Take the Plant Concepts loader DataFrame and insert its contents
         into the plantname, plantconcept, and plantstatus tables.
@@ -498,6 +506,8 @@ class PlantConcept(Operator):
         if validation['has_error']:
             raise ValueError(validation['error'])
 
+        to_return = None
+
         #
         # Upsert names into plantnames table
         #
@@ -508,6 +518,7 @@ class PlantConcept(Operator):
         pn_actions = super().upload_to_table("plant_name", 'pn',
             config_plant_name, 'plantname_id', df, False, conn,
             validate = False)
+        to_return = combine_json_return(to_return, pn_actions)
 
         # ... merge in newly created vb_pn_codes
         df = merge_vb_codes(
@@ -517,12 +528,21 @@ class PlantConcept(Operator):
         config_plant_concept.append('vb_pn_code')
 
         #
+        # Optionally deactivate old concepts from the same parties
+        #
+
+        deactivation_actions = self.deactivate_old_concepts(conn, df,
+                                                            what_to_deactivate)
+        to_return = combine_json_return(to_return, deactivation_actions)
+
+        #
         # Insert concepts into plantconcept table
         #
 
         df['user_pc_code'] = df['user_pc_code'].astype(str)
         pc_actions = super().upload_to_table("plant_concept", 'pc',
             config_plant_concept, 'plantconcept_id', df, True, conn)
+        to_return = combine_json_return(to_return, pc_actions)
 
         #
         # Insert status into plantstatus table
@@ -546,21 +566,8 @@ class PlantConcept(Operator):
 
         ps_actions = super().upload_to_table("plant_status", 'ps',
             config_plant_status, 'plantstatus_id', df, True, conn)
+        to_return = combine_json_return(to_return, ps_actions)
 
-        # TODO: decide which ones we actually want to return to the user -
-        # probably only `pc`?
-        to_return = {
-            'resources':{
-                'pn': pn_actions['resources']['pn'],
-                'pc': pc_actions['resources']['pc'],
-                'ps': ps_actions['resources']['ps']
-            },
-            'counts':{
-                'pn': pn_actions['counts']['pn'],
-                'pc': pc_actions['counts']['pc'],
-                'ps': ps_actions['counts']['ps']
-            }
-        }
         return to_return
 
     def upload_plant_names(self, df, conn):
@@ -742,3 +749,105 @@ class PlantConcept(Operator):
             }
         }
         return to_return
+
+    def deactivate_old_concepts(self, conn, df, what_to_deactivate):
+        """
+        Deactivate old concepts in VegBank
+
+        For a set of plant status records defined jointly by the combination of
+        `df` and `what_to_deactivate`, set the `stopdate` to `now` if it is not
+        already set to some date, and then likewise set the `usagestop` to `now`
+        (if not already set) for all related plant usage records.
+
+        Parameters:
+            conn (psycopg.Connection): Active database connection
+            df (pandas.DataFrame): Uploaded plant concept data
+            what_to_deactivate (str): Concept deactivation strategy
+
+        Returns:
+            dict: A dictionary containing either error messages in the event of
+                an error, or details about what was existing records were
+                deactivated if successfully completed. Example:
+                {
+                    "counts": {
+                        "pc_existing": {"inserted": 1},
+                    },
+                    "resources": {
+                        "pc_existing": [{"action": "STOP",
+                                "user_pc_code": "my_new_concept_1",
+                                "vb_pc_code": "pc.123"}],
+                    }
+                }
+        """
+        print("Applying stop dates to old concepts...")
+        if what_to_deactivate == 'by_party':
+            sql_deactivate_status = """
+                UPDATE plantstatus
+                   SET stopdate = NOW()
+                   WHERE stopdate IS NULL
+                     AND party_id = ANY(%s)
+                   RETURNING plantconcept_id,
+                             party_id,
+                             'STOP' AS action"""
+        elif what_to_deactivate == 'by_party_below_order':
+            sql_deactivate_status = """
+                UPDATE plantstatus
+                   SET stopdate = NOW()
+                   WHERE stopdate IS NULL
+                     AND party_id = ANY(%s)
+                     AND (plantlevel IS NULL OR
+                          LOWER(plantlevel) IN ('family', 'genus', 'species',
+                                                'subspecies', 'variety', 'forma'))
+                   RETURNING plantconcept_id,
+                             party_id,
+                             'STOP' AS action"""
+        else:
+            return  {
+                "resources": {
+                    "pc_existing": []
+                },
+                "counts": {
+                    "pc_existing": {
+                        "deactivated": 0
+                    }
+                }
+            }
+
+        # Put stop dates on old concepts
+        unique_status_parties = (
+            df['vb_status_py_code']
+            .str.removeprefix('py.')
+            .astype(int)
+            .unique()
+            .tolist()
+        )
+        sql = f"""\
+            WITH updated_status AS (
+              {sql_deactivate_status}
+            ),
+            updated_usage AS (
+              UPDATE plantusage
+                 SET usagestop = NOW()
+                 FROM updated_status
+                 WHERE plantusage.plantconcept_id = updated_status.plantconcept_id
+                   AND plantusage.usagestop IS NULL
+                 RETURNING plantusage.plantconcept_id
+            ) SELECT action,
+                     'py.' || party_id AS vb_py_code,
+                     'pc.' || plantconcept_id AS vb_pc_code
+                FROM updated_status"""
+
+        with conn.cursor() as cur:
+            cur.execute(sql, (unique_status_parties,))
+            pc_deactivated = cur.fetchall()
+
+        return {
+            "resources": {
+                "pc_existing": pc_deactivated
+            },
+            "counts": {
+                "pc_existing": {
+                    "deactivated": len(pc_deactivated)
+                }
+            }
+        }

--- a/src/vegbank/vegbankapi.py
+++ b/src/vegbank/vegbankapi.py
@@ -191,7 +191,7 @@ def taxon_observations(vb_code):
 
     Parameters:
         vb_code (str or None): The unique identifier for the taxon
-            observation concept being retrieved, or for a resource of a
+            observation being retrieved, or for a resource of a
             different type used to focus taxon observation retrieval. If
             None, retrieves all taxon observations.
 
@@ -701,6 +701,11 @@ def plant_concepts(vb_code):
     plant concept records. Collection responses may be further mediated by
     pagination parameters and other filtering query parameters.
 
+    POST: Upload a set of files conforming with the plant concept loader schema,
+    and return counts and created codes of newly inserted records. Includes an
+    option for deactivating existing concepts superseded by the newly uploaded
+    data.
+
     Parameters:
         vb_code (str or None): The unique identifier for the plant
             concept being retrieved, or for a resource of a different type used
@@ -724,6 +729,27 @@ def plant_concepts(vb_code):
         create_parquet (str, optional): Whether to return data as Parquet
             rather than JSON. Accepts 'true' or 'false' (case-insensitive).
             Defaults to False.
+
+    POST Parameters:
+        plant_concepts (FileStorage): Parquet file containing new plant concepts
+            and corresponding status details.
+        plant_names (FileStorage, optional): Parquet file containing zero or
+            more plant name usages (and related details) for each concept.
+        plant_correlations (FileStorage, optional): Parquet file containing
+            correlations between concepts.
+        parties (FileStorage, optional): Parquet file containing one or more new
+            parties (people or organizations) providing perspectives on the
+            uploaded concepts.
+        references (FileStorage, optional): Parquet file containing one or more
+            new references associated with the uploaded plant concepts.
+        deactivation (str, optional): Which existing plant concepts in VegBank
+            should be deactivated when inserting the new concepts. Can be "none"
+            (don't deactivate any records), "by_party" (deactivate all existing
+            plant status and related usage records associated with any parties
+            that are also associated with the uploaded concepts), or
+            "by_party_below_order" (like "by_party", but only apply to concepts
+            at the family taxonomic level or lower, or with unspecified level).
+            Defaults to "none".
 
     Returns:
         flask.Response: A Flask response object containing:


### PR DESCRIPTION
### What

This PR adds an optional step to the plant concept upload pipeline for "deactivating" (i.e., marking as no longer current) a designated set of existing plant concepts already in VegBank.

Options include:
- Don't deactivate
- Deactivate all active concepts with status records that are linked to any existing VegBank parties referenced by newly uploaded concepts
- As above, but don't deactivate concepts at taxonomic levels of Order or higher

### Why

Because when we add a set of new concepts (e.g., the USDA plants list from 2026) that supersede earlier concepts (e.g., the USDA plants list uploaded back in 2015), we need to set status and usage stop dates on the old concepts so that they are no longer treated as `current` concepts.

We provide an option for leaving older Order and higher concepts as active because when we upload USDA concepts, we only create Family and lower records, while linking newly inserted Families upward to existing parent Order records to complete the full hierarchy.

### How
- Updated the PlantConcept operator to handle the new `deactivation` query parameter, and add a new appropriate deactivation step to the `upload_all()` pipeline.
- Added docstring documentaton for the `POST /plant-concepts` view function.

### Testing

Tested manually (🤷) from R using the following cases:
- No `deactivation` parameter: Deactivation step is skipped (`deactivated 0 pc_existing record(s)`)
- `deactivation = "none"`: Deactivation step is skipped (`deactivated 0 pc_existing record(s)`)
- `deactivation = "by_party_below_order"`: Deactivation runs as expected (`deactivated 182441 pc_existing record(s)`)
- `deactivation = "by_party"`: Deactivation runs as expected (`deactivated 182234 pc_existing record(s)`)
- `deactivation = "foo"`: Error response as expected
```
Error in `req_perform()` at vegbankr/R/utils.R:133:5:
! HTTP 500 Internal Server Error.
ℹ an error occurred here during upload: When provided, 'deactivation' must be 'none', 'by_party', or 'by_party_below_order'.
```

Note the following DB counts, matching output above:
```sql
SELECT COUNT(*) FROM plantstatus WHERE stopdate IS NULL AND party_id = 511;
-- 182441
```
```sql
SELECT COUNT(*) FROM plantstatus WHERE stopdate IS NULL AND party_id = 511
  AND (plantlevel IS NULL OR LOWER(plantlevel) IN ('family', 'genus', 'species', 'subspecies', 'variety', 'forma'));
-- 182234
```

### Demo

##### Upload from R

Notice the deactivated record counts and returned codes.

```r
> response <- vb_upload("plant-concepts",
    references = references,
    plant_concepts = plant_concepts %>% filter(user_pc_code %in% test_codes),
    plant_names = plant_names %>% filter(user_pc_code %in% test_codes),
    plant_correlations = plant_correlations %>% filter(
      user_pc_code %in% test_codes, user_correlated_pc_code %in% test_codes),
    query_params = list(deactivation = "by_party_below_order"),
    dry_run = TRUE)
```
```
dry run - rolling back transaction.
-> inserted 5 pc record(s)
-> deactivated 182234 pc_existing record(s)
-> inserted 5 pn record(s)
-> inserted 5 ps record(s)
-> inserted 17 pu record(s)
-> inserted 16 pun record(s)
-> inserted 1 px record(s)
-> inserted 1 rf record(s)
$pc
      action user_pc_code vb_pc_code
1   inserted     pc.91653 pc.1242447
2   inserted        QURUB pc.1242448
...      ...          ...        ...
4   inserted         QURU pc.1242450
5   inserted        QUERC pc.1242451

$pc_existing
       action vb_pc_code vb_py_code
1        STOP  pc.152246     py.511
2        STOP  pc.152731     py.511
...       ...        ...        ...
182233   STOP  pc.402420     py.511
182234   STOP  pc.402421     py.511

$pn
      action                                     user_pn_code vb_pn_code
1   inserted                                         Fagaceae  pn.313627
2   inserted Quercus rubra L. var. borealis (Michx. f.) Farw.  pn.299708
...      ...                                              ...        ...
4   inserted                                 Quercus rubra L.  pn.168232
5   inserted                                       Quercus L.   pn.17912

$ps
      action user_ps_code vb_ps_code
1   inserted     pc.91653 ps.1115389
2   inserted        QURUB ps.1115390
...      ...          ...        ...
4   inserted         QURU ps.1115392
5   inserted        QUERC ps.1115393

$pu
      action                        user_pu_code vb_pu_code
1   inserted             pc.91653 English common pu.3845556
2   inserted pc.91653 Scientific without authors pu.3845557
...      ...                                 ...        ...
16  inserted    QURUB Scientific without authors pu.3845571
17  inserted                          QURUB Code pu.3845572

$pun
      action                user_pn_code vb_pn_code
1   inserted                Beech family  pn.314552
2   inserted                    Fagaceae  pn.313627
...      ...                         ...        ...
15  inserted Quercus rubra var. borealis  pn.299709
16  inserted                       QURUB  pn.299707

$px
    action      user_px_code vb_px_code
1 inserted QURUA->pc.1242448  px.484671

$rf
    action user_rf_code vb_rf_code
1 inserted    USDA_2026   rf.87749
```

##### Flask console logging

Log output from a locally patched version of this branch that also has some timing and print statements. Notice the step for "**Applying stop dates to old concepts...**".

```
Received POST request for /plant-concepts
dataframe loaded with 1 records.
dataframe loaded with 93839 records.
dataframe loaded with 324361 records.
dataframe loaded with 44150 records.
Uploading reference dataframe with 1 records.
  -> Completed in 0.076652 seconds
Uploading plant_name dataframe with 93839 records.
  -> Completed in 5.861645 seconds
Applying stop dates to old concepts...
  -> Completed in 33.569031 seconds
Uploading plant_concept dataframe with 93839 records.
  -> Completed in 12.152251 seconds
Uploading plant_status dataframe with 93839 records.
  -> Completed in 11.796884 seconds
Uploading plant_name dataframe with 324361 records.
  -> Completed in 18.113575 seconds
Uploading plant_usage dataframe with 324361 records.
  -> Completed in 34.121909 seconds
Uploading plant_correlation dataframe with 44150 records.
  -> Completed in 3.576076 seconds
```