### PR TITLE
Set self.request instance attribute

### DIFF
--- a/src/vegbank/operators/operator_parent_class.py
+++ b/src/vegbank/operators/operator_parent_class.py
@@ -403,6 +403,7 @@ class Operator:
             self.query_mode = 'count'
         else:
             self.query_mode = 'normal'
+        self.request = request
 
         try:
             params = self.validate_query_params(request.args)


### PR DESCRIPTION
### What

This adds a missing line of code that I inadvertently left out of an earlier commit (but had in my local repo at test time). Perils of local-only testing....

### Why

So that `GET /plant-concepts` works again!

### How

Added a missing line capturing the Flask request as an operator instance attribute, which is then used in the Plant Concept operator.

### Testing

Uh .... manually tested again, but this time actually remembering to use a clean directory.