### PR TITLE
Provide options for community concept deactivation at upload time

### DIFF
--- a/src/vegbank/operators/CommunityConcept.py
+++ b/src/vegbank/operators/CommunityConcept.py
@@ -41,6 +41,8 @@ class CommunityConcept(Operator):
         self.sort_options = ["default", "comm_name", "obs_count"]
         self.status_options = ["any", "current", "accepted", "current_accepted"]
         self.default_status = "any"
+        self.deactivation_options = ["none", "by_party"]
+        self.default_deactivation = "none"
 
     def configure_query(self, *args, **kwargs):
         query_type = self.detail
@@ -408,7 +410,12 @@ class CommunityConcept(Operator):
                         rf_actions['resources']['rf'], data['cc'],
                         {"user_rf_code": "user_status_rf_code",
                          "vb_rf_code": "vb_status_rf_code"})
-                cc_actions = self.upload_community_concepts(data['cc'], conn)
+                what_to_deactivate = process_option_param('deactivation',
+                    request.args.get('deactivation', self.default_deactivation),
+                    self.deactivation_options)
+
+                cc_actions = self.upload_community_concepts(
+                    data['cc'], conn, what_to_deactivate = what_to_deactivate)
                 to_return = combine_json_return(to_return, cc_actions)
 
                 # Prep & insert any new community names
@@ -481,7 +488,7 @@ class CommunityConcept(Operator):
                 f"an error occurred here during upload: {str(e)}"), 500
         return jsonify(to_return)
 
-    def upload_community_concepts(self, df, conn):
+    def upload_community_concepts(self, df, conn, what_to_deactivate = 'none'):
         """
         Take the Community Concepts loader DataFrame and insert its contents
         into the commname, commconcept, and commstatus tables.
@@ -555,6 +562,8 @@ class CommunityConcept(Operator):
         if validation['has_error']:
             raise ValueError(validation['error'])
 
+        to_return = None
+
         #
         # Upsert names into commnames table
         #
@@ -565,6 +574,7 @@ class CommunityConcept(Operator):
         cn_actions = super().upload_to_table("comm_name", 'cn',
             config_comm_name, 'commname_id', df, False, conn,
             validate = False)
+        to_return = combine_json_return(to_return, cn_actions)
 
         # ... merge in newly created vb_cn_codes
         df = merge_vb_codes(
@@ -574,12 +584,21 @@ class CommunityConcept(Operator):
         config_comm_concept.append('vb_cn_code')
 
         #
+        # Optionally deactivate old concepts from the same parties
+        #
+
+        deactivation_actions = self.deactivate_old_concepts(conn, df,
+                                                            what_to_deactivate)
+        to_return = combine_json_return(to_return, deactivation_actions)
+
+        #
         # Insert concepts into commconcept table
         #
 
         df['user_cc_code'] = df['user_cc_code'].astype(str)
         cc_actions = super().upload_to_table("comm_concept", 'cc',
             config_comm_concept, 'commconcept_id', df, True, conn)
+        to_return = combine_json_return(to_return, cc_actions)
 
         #
         # Insert status into commstatus table
@@ -603,21 +622,8 @@ class CommunityConcept(Operator):
 
         cs_actions = super().upload_to_table("comm_status", 'cs',
             config_comm_status, 'commstatus_id', df, True, conn)
+        to_return = combine_json_return(to_return, cs_actions)
 
-        # TODO: decide which ones we actually want to return to the user -
-        # probably only `cc`?
-        to_return = {
-            'resources':{
-                'cn': cn_actions['resources']['cn'],
-                'cc': cc_actions['resources']['cc'],
-                'cs': cs_actions['resources']['cs']
-            },
-            'counts':{
-                'cn': cn_actions['counts']['cn'],
-                'cc': cc_actions['counts']['cc'],
-                'cs': cs_actions['counts']['cs']
-            }
-        }
         return to_return
 
     def upload_community_names(self, df, conn):
@@ -799,3 +805,93 @@ class CommunityConcept(Operator):
             }
         }
         return to_return
+
+    def deactivate_old_concepts(self, conn, df, what_to_deactivate):
+        """
+        Deactivate old concepts in VegBank
+
+        For a set of community status records defined jointly by the combination of
+        `df` and `what_to_deactivate`, set the `stopdate` to `now` if it is not
+        already set to some date, and then likewise set the `usagestop` to `now`
+        (if not already set) for all related community usage records.
+
+        Parameters:
+            conn (psycopg.Connection): Active database connection
+            df (pandas.DataFrame): Uploaded community concept data
+            what_to_deactivate (str): Concept deactivation strategy
+
+        Returns:
+            dict: A dictionary containing either error messages in the event of
+                an error, or details about what was existing records were
+                deactivated if successfully completed. Example:
+                {
+                    "counts": {
+                        "cc_existing": {"inserted": 1},
+                    },
+                    "resources": {
+                        "cc_existing": [{"action": "STOP",
+                                "user_cc_code": "my_new_concept_1",
+                                "vb_cc_code": "cc.123"}],
+                    }
+                }
+        """
+        print("Applying stop dates to old concepts...")
+        if what_to_deactivate == 'by_party':
+            sql_deactivate_status = """
+                UPDATE commstatus
+                   SET stopdate = NOW()
+                   WHERE stopdate IS NULL
+                     AND party_id = ANY(%s)
+                   RETURNING commconcept_id,
+                             party_id,
+                             'STOP' AS action"""
+        else:
+            return  {
+                "resources": {
+                    "cc_existing": []
+                },
+                "counts": {
+                    "cc_existing": {
+                        "deactivated": 0
+                    }
+                }
+            }
+
+        # Put stop dates on old concepts
+        unique_status_parties = (
+            df['vb_status_py_code']
+            .str.removeprefix('py.')
+            .astype(int)
+            .unique()
+            .tolist()
+        )
+        sql = f"""\
+            WITH updated_status AS (
+              {sql_deactivate_status}
+            ),
+            updated_usage AS (
+              UPDATE commusage
+                 SET usagestop = NOW()
+                 FROM updated_status
+                 WHERE commusage.commconcept_id = updated_status.commconcept_id
+                   AND commusage.usagestop IS NULL
+                 RETURNING commusage.commconcept_id
+            ) SELECT action,
+                     'py.' || party_id AS vb_py_code,
+                     'cc.' || commconcept_id AS vb_cc_code
+                FROM updated_status"""
+
+        with conn.cursor() as cur:
+            cur.execute(sql, (unique_status_parties,))
+            cc_deactivated = cur.fetchall()
+
+        return {
+            "resources": {
+                "cc_existing": cc_deactivated
+            },
+            "counts": {
+                "cc_existing": {
+                    "deactivated": len(cc_deactivated)
+                }
+            }
+        }

--- a/src/vegbank/vegbankapi.py
+++ b/src/vegbank/vegbankapi.py
@@ -639,11 +639,35 @@ def community_concepts(vb_code):
     be further mediated by pagination parameters and other filtering query
     parameters.
 
+    POST: Upload a set of files conforming with the comm concept loader schema,
+    and return counts and created codes of newly inserted records. Includes an
+    option for deactivating existing concepts superseded by the newly uploaded
+    data.
+
     Parameters:
         vb_code (str or None): The unique identifier for the community concept
             being retrieved, or for a resource of a different type used to focus
             community concept retrieval. If None, retrieves all community
             concepts.
+
+    POST Parameters:
+        community_concepts (FileStorage): Parquet file containing new community
+            concepts and corresponding status details.
+        community_names (FileStorage, optional): Parquet file containing zero or
+            more community name usages (and related details) for each concept.
+        community_correlations (FileStorage, optional): Parquet file containing
+            correlations between concepts.
+        parties (FileStorage, optional): Parquet file containing one or more new
+            parties (people or organizations) providing perspectives on the
+            uploaded concepts.
+        references (FileStorage, optional): Parquet file containing one or more
+            new references associated with the uploaded community concepts.
+        deactivation (str, optional): Which existing community concepts in VegBank
+            should be deactivated when inserting the new concepts. Can be "none"
+            (don't deactivate any records) or "by_party" (deactivate all existing
+            community status and related usage records associated with any
+            parties that are also associated with the uploaded concepts).
+            Defaults to "none".
 
     GET Query Parameters:
         search (str, optional): Community name search query.


### PR DESCRIPTION
### What

This PR is basically a repeat of [PR 338](https://github.com/NCEAS/vegbank2/pull/338) but now for community concepts. It adds an optional step to the community concept upload pipeline for "deactivating" (i.e., marking as no longer current) a designated set of existing community concepts already in VegBank.

Options are:
- `deactivation=none`: Don't deactivate
- `deactivation=by_party`: Deactivate all active concepts with status records that are linked to any existing VegBank parties referenced by newly uploaded concepts

### Why

Because when we add a set of new concepts (e.g., the US NVC 3.0 community concepts) that supersede earlier concepts (e.g., NVC concepts loaded in the past), we need to set status and usage stop dates on the old concepts so that they are no longer treated as `current` concepts.

### How
- Updated the CommunityConcept operator to handle the new `deactivation` query parameter, and add a new appropriate deactivation step to the `upload_all()` pipeline.
- Added docstring documentaton for the `POST /community-concepts` view function.

### Testing

Tested manually (🤷) from R using the following cases:
- No `deactivation` parameter: Deactivation step is skipped (`deactivated 0 cc_existing record(s)`)
- `deactivation = "none"`: Deactivation step is skipped (`deactivated 0 cc_existing record(s)`)
- `deactivation = "by_party"`: Deactivation runs as expected (`deactivated 12530 cc_existing record(s)`)
- `deactivation = "foo"`: Error response as expected
```
Error in `req_perform()` at vegbankr/R/utils.R:133:5:
! HTTP 500 Internal Server Error.
ℹ an error occurred here during upload: When provided, 'deactivation' must be 'none' or 'by_party'.
```

### Demo

##### Upload from R

Notice the deactivated record counts and returned codes.

```r
> responses <- vb_upload_community_concepts(
    references = references,
    community_concepts = community_concepts,
    community_names = community_names,
    community_correlations = community_correlations,
    what_to_deactivate = "by_party",
    dry_run=TRUE)
```
```
dry run - rolling back transaction.
-> inserted 9375 cc record(s)
-> deactivated 12530 cc_existing record(s)
-> inserted 9286 cn record(s)
-> inserted 9375 cs record(s)
-> inserted 37326 cu record(s)
-> inserted 37170 cun record(s)
-> inserted 971 cx record(s)
-> inserted 1 rf record(s)
$cc
     action user_cc_code vb_cc_code
1    INSERT          B01  cc.138995
2    INSERT          S51  cc.138996
...     ...          ...        ...
9374 INSERT          S78  cc.148340
9375 INSERT         F154  cc.148341

$cc_existing
      action vb_cc_code vb_py_code
1       STOP   cc.41336     py.512
2       STOP   cc.41337     py.512
...      ...        ...        ...
12529   STOP   cc.91983     py.512
12530   STOP   cc.91984     py.512

$cn
     action                   user_cn_code vb_cn_code
1     MATCH                Tropical Forest  cn.192201
2     MATCH            Tropical Rainforest  cn.192203
...     ...                            ...        ...
9285 INSERT Anthropogenic Marine Shoreline  cn.231879
9286 INSERT     Developed Marine Shoreline  cn.232383

$cs
     action user_cs_code vb_cs_code
1    INSERT          B01  cs.138905
2    INSERT          S51  cs.138906
...     ...          ...        ...
9374 INSERT          S78  cs.148278
9375 INSERT         F154  cs.148279

$cu
      action   user_cu_code vb_cu_code
1     INSERT B01 Translated  cu.394455
2     INSERT       B01 Code  cu.394456
...      ...            ...        ...
37325 INSERT      F154 Code  cu.431779
37326 INSERT       F154 UID  cu.431780

$cun
      action             user_cn_code vb_cn_code
1      MATCH          Tropical Forest  cn.192201
2      MATCH                      B01  cn.192204
...      ...                      ...        ...
37169 INSERT                     F154  cn.233382
37170 INSERT ELEMENT_GLOBAL.2.1299023  cn.235983

$cx
    action         user_cx_code vb_cx_code
1   INSERT        B01->cc.53473   cx.40496
2   INSERT        B02->cc.53473   cx.40497
...    ...                  ...        ...
970 INSERT CEGL008942->cc.48869   cx.41465
971 INSERT CEGL008943->cc.48869   cx.41466

$rf
  action user_rf_code vb_rf_code
1 INSERT    USNVC_3.0   rf.87807
```