### PR TITLE
Require start_date in plant concept uploads

### DIFF
--- a/src/vegbank/operators/PlantConcept.py
+++ b/src/vegbank/operators/PlantConcept.py
@@ -554,7 +554,7 @@ class PlantConcept(Operator):
                       config_plant_concept,
                       config_plant_status]
         # TODO: finalize this here, unless/until we move this to configuration
-        required_fields = ['user_pc_code', 'name', 'vb_rf_code',
+        required_fields = ['user_pc_code', 'name', 'vb_rf_code', 'start_date',
                            'plant_concept_status', 'vb_status_py_code']
 
         # Run basic input data validation


### PR DESCRIPTION
### What

Require `start_date` in the plant concept upload table.

### Why

Because `plantstatus.startdate` is a required field in the database.

### How

Added `start_date` to the `required_fields` array.

### Testing

Manually tested that the API returns a friendly message when this field is missing, vs failing downstream with a database integrity constraint error.

### Demo

##### What happened before:

```r
responses <- vb_upload_plant_concepts(
  plant_concepts = data.frame(
    user_pc_code="test",
    vb_rf_code="rf.33",
    vb_status_py_code="py.511",
    plant_concept_status="accepted",
    name="test plant"),
  dry_run=TRUE)

# Error in `req_perform()`:
# ! HTTP 500 Internal Server Error.
# ℹ an error occurred here during upload: null value in column "startdate" of relation
#   "plant_status_temp" violates not-null constraint DETAIL: Failing row contains (test, null, null,
#   accepted, pc.2180948, test, null, null, null, null, py.511, null, test, pc.2180948).
```

##### What happens now:

```r
responses <- vb_upload_plant_concepts(
  plant_concepts = data.frame(
    user_pc_code="test",
    vb_rf_code="rf.33",
    vb_status_py_code="py.511",
    plant_concept_status="accepted",
    name="test plant"),
  dry_run=TRUE)

# Error in `req_perform()`:
# ! HTTP 500 Internal Server Error.
# ℹ an error occurred here during upload: The following required columns for plant concepts must be
#   present with no null values : start_date.
```