### PR TITLE
Feature 357 enhanced vb merge

### DIFF
--- a/src/vegbank/operators/CommunityConcept.py
+++ b/src/vegbank/operators/CommunityConcept.py
@@ -392,8 +392,7 @@ class CommunityConcept(Operator):
                     rf_actions = None
 
                 # Prep & insert all new community concepts
-                if (py_actions is not None and
-                        'user_status_py_code' in data['cc'].columns):
+                if py_actions is not None:
                     # ... merge in newly created vb_py_codes
                     data['cc'] = merge_vb_codes(
                         py_actions['resources']['py'], data['cc'],
@@ -435,8 +434,7 @@ class CommunityConcept(Operator):
                         {"user_cs_code": "user_cc_code",
                          "vb_cs_code": "vb_cs_code"})
                     # ... merge in newly created usage vb_py_codes
-                    if (py_actions is not None and
-                            'user_usage_py_code' in data['cn'].columns):
+                    if py_actions is not None:
                         data['cn'] = merge_vb_codes(
                             py_actions['resources']['py'], data['cn'],
                             {"user_py_code": "user_usage_py_code",
@@ -453,11 +451,10 @@ class CommunityConcept(Operator):
                         cc_actions['resources']['cc'], data['cx'],
                         {"user_cc_code": "user_cc_code",
                          "vb_cc_code": "vb_cc_code"})
-                    if 'user_correlated_cc_code' in data['cx'].columns:
-                        data['cx'] = merge_vb_codes(
-                            cc_actions['resources']['cc'], data['cx'],
-                            {"user_cc_code": "user_correlated_cc_code",
-                             "vb_cc_code": "vb_correlated_cc_code"})
+                    data['cx'] = merge_vb_codes(
+                        cc_actions['resources']['cc'], data['cx'],
+                        {"user_cc_code": "user_correlated_cc_code",
+                         "vb_cc_code": "vb_correlated_cc_code"})
                     cx_actions = self.upload_community_correlations(data['cx'], conn)
                     to_return = combine_json_return(to_return, cx_actions)
                 else:
@@ -614,7 +611,8 @@ class CommunityConcept(Operator):
              "vb_cc_code": "vb_cc_code"})
         config_comm_status.append('vb_cc_code')
 
-        # ... merge in newly created vb_cc_codes
+        # ... merge in any newly created vb_cc_codes for user-uploaded
+        # parent concept references
         df = merge_vb_codes(
             cc_actions['resources']['cc'], df,
             {"user_cc_code": "user_parent_cc_code",

--- a/src/vegbank/operators/PlantConcept.py
+++ b/src/vegbank/operators/PlantConcept.py
@@ -615,7 +615,8 @@ class PlantConcept(Operator):
              "vb_pc_code": "vb_pc_code"})
         config_plant_status.append('vb_pc_code')
 
-        # ... merge in newly created vb_pc_codes
+        # ... merge in any newly created vb_pc_codes for user-uploaded
+        # parent concept references
         df = merge_vb_codes(
             pc_actions['resources']['pc'], df,
             {"user_pc_code": "user_parent_pc_code",

--- a/src/vegbank/utilities.py
+++ b/src/vegbank/utilities.py
@@ -213,8 +213,8 @@ def merge_vb_codes(inserted_codes, df, mapping):
             where keys are column names and values are lists of code values.
             Must contain columns that will be renamed according to the mapping.
         df (pandas.DataFrame): The target dataframe to merge the new codes into.
-            Should contain a column matching the user code field specified in
-            the mapping.
+            If the user code column specified in the mapping is not present, df
+            is returned unchanged.
         mapping (dict): A dictionary mapping the column names from
             inserted_codes to the column names in the target dataframe. Should
             have exactly two key-value pairs: one for the user code column and
@@ -222,11 +222,15 @@ def merge_vb_codes(inserted_codes, df, mapping):
             "user_status_py_code", "vb_py_code": "vb_status_py_code"}).
 
     Returns:
-        pandas.DataFrame: The modified dataframe with the new VB codes merged in.
-            Existing VB code values are preserved when conflicts occur.
+        pandas.DataFrame: The modified dataframe with the new VB codes merged
+            in, or the original dataframe unchanged if the user code column is
+            absent. Existing VB code values are preserved when conflicts occur.
     '''
     codes_df = pd.DataFrame(inserted_codes).rename(columns=mapping)
     user_col, vb_col = list(mapping.values())
+    if user_col not in df.columns:
+        print(f"No '{user_col}' column found in df -- skipping merge.")
+        return df
     df = df.merge(codes_df[[user_col, vb_col]], on=user_col, how='left')
     if f'{vb_col}_x' in df:
         df[vb_col] = df[f'{vb_col}_x'].combine_first(df[f'{vb_col}_y'])


### PR DESCRIPTION
### What

This PR enhances the merge utility used in upload pipelines to return the input dataframe unchanged if the desired join column doesn't exist.

It also adds `start_date` as a required column for community concept uploads, just like we recently did for plant concepts. Not doing a separate PR for this because it's so dang small!

### Why

The merge utility is used in numerous places in the upload API to join generated `vb_x_codes` back into user data via `user_x_codes`, for use in populating foreign keys in subsequent insert steps. However, it requires that the `user_x_code` exists in the input data, and this might not always be the case. So far we've been adding `if` guards to skip merging if the relevant column doesn't exist. However, to simplify things, here we're instead enhancing the utility function itself such that if the `user_x_code` field doesn't exist in the user data, the data frame is returned unchanged. Previously, this resulted in an error.

### How

- Updated the `merge_vb_codes()` to return the input DF unchanged when the specified user code column is absent
- Updated PlantConcept and CommunityConcept upload methods to remove the `if` gates based on presence of the column
- Also added `start_date` as a required Comm Concept upload column, as mentioned


### Demo (with `vegbankr`)

Consider the following minimal plant concepts upload table. It doesn't contain a `user_parent_pc_code` column, which should be completely fine because this is optional.

```r
plant_concepts <- data.frame(
  user_pc_code = "new_plant_1",
  name = "Plantus conceptus",
  vb_rf_code = "rf.87797",
  plant_concept_status = "not accepted",
  vb_status_py_code = 'py.511',
  start_date = '2026-03-01'
)
````

##### What happened before this PR

Internally, the API tried to do a join on `user_parent_pc_code` to add `vb_parent_pc_codes` after inserting new plant concepts, but failed with a cryptic error because the column doesn't exist in the data frame:

```r
vb_upload_plant_concepts(plant_concepts, what_to_deactivate='none', dry_run = TRUE)
# Error in `req_perform()`:
# ! HTTP 500 Internal Server Error.
# ℹ an error occurred here during upload: 'user_parent_pc_code'
```

##### What happens after this PR

The merge step silently returns the input dataframe without doing anything, and the upload process proceeds on its merry way:

```r
vb_upload_plant_concepts(plant_concepts, what_to_deactivate='none', dry_run = TRUE)
# dry run - rolling back transaction.
# -> inserted 1 pc record(s)
# -> deactivated 0 pc_existing record(s)
# -> inserted 1 pn record(s)
# -> inserted 1 ps record(s)
```