### PR TITLE
Use concept status parameter to filter children

### DIFF
--- a/api/openapi.yml
+++ b/api/openapi.yml
@@ -2620,7 +2620,7 @@ components:
         enum: [any, current, accepted, current_accepted]
         default: any
       description: |
-        Status criterion for returned plant concepts:
+        Status criterion for returned plant concepts and their children:
         - `any`: Returns matching concepts regardless of status
         - `current`: Only returns concepts that don't have (past) status stop dates
         - `accepted`: Only returns concepts that have an accepted status

--- a/src/vegbank/operators/CommunityConcept.py
+++ b/src/vegbank/operators/CommunityConcept.py
@@ -17,6 +17,7 @@ from psycopg.rows import dict_row
 from psycopg import connect
 from flask import jsonify
 
+
 class CommunityConcept(Operator):
     """
     Defines operations related to the exchange of community concept data with
@@ -48,6 +49,54 @@ class CommunityConcept(Operator):
         query_type = self.detail
         if self.with_nested == 'true':
             query_type += "_nested"
+
+        if self.request.args.get('status') == 'current':
+            always_condition = {
+                'sql': """\
+                    EXISTS (
+                        SELECT commconcept_id
+                          FROM commstatus cs
+                          WHERE cc.commconcept_id = cs.commconcept_id
+                            AND cs.stopdate IS NULL)
+                    """,
+                'params': []
+            }
+            and_child_status = """
+                 AND stopdate IS NULL"""
+        elif self.request.args.get('status') == 'accepted':
+            always_condition = {
+                'sql': """\
+                    EXISTS (
+                        SELECT commconcept_id
+                          FROM commstatus cs
+                          WHERE cc.commconcept_id = cs.commconcept_id
+                            AND LOWER(cs.commconceptstatus) LIKE 'accepted%%')
+                    """,
+                'params': []
+            }
+            and_child_status = """
+                 AND commconceptstatus LIKE 'accepted%%'"""
+        elif self.request.args.get('status') == 'current_accepted':
+            always_condition = {
+                'sql': """\
+                    EXISTS (
+                        SELECT commconcept_id
+                          FROM commstatus cs
+                          WHERE cc.commconcept_id = cs.commconcept_id
+                            AND LOWER(cs.commconceptstatus) LIKE 'accepted%%'
+                            AND cs.stopdate IS NULL)
+                    """,
+                'params': []
+            }
+            and_child_status = """
+                 AND commconceptstatus LIKE 'accepted%%'
+                 AND stopdate IS NULL"""
+        else:
+            always_condition = {
+                'sql': None,
+                'params': []
+            }
+            and_child_status = ""
 
         base_columns = {'*': "*"}
         base_columns_search = {
@@ -107,7 +156,7 @@ class CommunityConcept(Operator):
                 WHERE commconcept_id = cc.commconcept_id
             ) cn ON true
             """
-        from_sql['full_nested'] = from_sql['full'].rstrip() + """
+        from_sql['full_nested'] = from_sql['full'].rstrip() + f"""
             LEFT JOIN LATERAL (
               SELECT JSON_AGG(JSON_BUILD_OBJECT(
                          'cc_code', 'cc.' || ch_cc.commconcept_id,
@@ -115,7 +164,8 @@ class CommunityConcept(Operator):
                        )) AS children
                FROM commstatus ch_st
                JOIN commconcept ch_cc USING (commconcept_id)
-               WHERE ch_st.commparent_id = cc.commconcept_id
+               WHERE ch_st.commparent_id = cc.commconcept_id{
+                     and_child_status}
             ) children ON true
             LEFT JOIN LATERAL (
               SELECT JSON_AGG(JSON_BUILD_OBJECT(
@@ -141,46 +191,6 @@ class CommunityConcept(Operator):
             ORDER BY COALESCE(cc.d_obscount, 0) {self.direction},
                      cc.commconcept_id {self.direction}
             """
-
-        if self.request.args.get('status') == 'current':
-            always_condition = {
-                'sql': """\
-                    EXISTS (
-                        SELECT commconcept_id
-                          FROM commstatus cs
-                          WHERE cc.commconcept_id = cs.commconcept_id
-                            AND cs.stopdate IS NULL)
-                    """,
-                'params': []
-            }
-        elif self.request.args.get('status') == 'accepted':
-            always_condition = {
-                'sql': """\
-                    EXISTS (
-                        SELECT commconcept_id
-                          FROM commstatus cs
-                          WHERE cc.commconcept_id = cs.commconcept_id
-                            AND LOWER(cs.commconceptstatus) LIKE 'accepted%%')
-                    """,
-                'params': []
-            }
-        elif self.request.args.get('status') == 'current_accepted':
-            always_condition = {
-                'sql': """\
-                    EXISTS (
-                        SELECT commconcept_id
-                          FROM commstatus cs
-                          WHERE cc.commconcept_id = cs.commconcept_id
-                            AND LOWER(cs.commconceptstatus) LIKE 'accepted%%'
-                            AND cs.stopdate IS NULL)
-                    """,
-                'params': []
-            }
-        else:
-            always_condition = {
-                'sql': None,
-                'params': []
-            }
 
         self.query = {}
         self.query['base'] = {

--- a/src/vegbank/operators/PlantConcept.py
+++ b/src/vegbank/operators/PlantConcept.py
@@ -50,6 +50,54 @@ class PlantConcept(Operator):
         if self.with_nested == 'true':
             query_type += "_nested"
 
+        if self.request.args.get('status') == 'current':
+            always_condition = {
+                'sql': """\
+                    EXISTS (
+                        SELECT plantconcept_id
+                          FROM plantstatus ps
+                          WHERE pc.plantconcept_id = ps.plantconcept_id
+                            AND ps.stopdate IS NULL)
+                    """,
+                'params': []
+            }
+            and_child_status = """
+                 AND stopdate IS NULL"""
+        elif self.request.args.get('status') == 'accepted':
+            always_condition = {
+                'sql': """\
+                    EXISTS (
+                        SELECT plantconcept_id
+                          FROM plantstatus ps
+                          WHERE pc.plantconcept_id = ps.plantconcept_id
+                            AND ps.plantconceptstatus LIKE 'accepted%%')
+                    """,
+                'params': []
+            }
+            and_child_status = """
+                 AND plantconceptstatus LIKE 'accepted%%'"""
+        elif self.request.args.get('status') == 'current_accepted':
+            always_condition = {
+                'sql': """\
+                    EXISTS (
+                        SELECT plantconcept_id
+                          FROM plantstatus ps
+                          WHERE pc.plantconcept_id = ps.plantconcept_id
+                            AND ps.plantconceptstatus LIKE 'accepted%%'
+                            AND ps.stopdate IS NULL)
+                    """,
+                'params': []
+            }
+            and_child_status = """
+                 AND plantconceptstatus LIKE 'accepted%%'
+                 AND stopdate IS NULL"""
+        else:
+            always_condition = {
+                'sql': None,
+                'params': []
+            }
+            and_child_status = ""
+
         base_columns = {'*': "*"}
         base_columns_search = {
             'search_rank': "TS_RANK(pc.search_vector, " +
@@ -108,7 +156,7 @@ class PlantConcept(Operator):
                 WHERE plantconcept_id = pc.plantconcept_id
             ) pn ON true
             """
-        from_sql['full_nested'] = from_sql['full'].rstrip() + """
+        from_sql['full_nested'] = from_sql['full'].rstrip() + f"""
             LEFT JOIN LATERAL (
               SELECT JSON_AGG(JSON_BUILD_OBJECT(
                          'pc_code', 'pc.' || ch_pc.plantconcept_id,
@@ -116,7 +164,8 @@ class PlantConcept(Operator):
                        )) AS children
                FROM plantstatus ch_st
                JOIN plantconcept ch_pc USING (plantconcept_id)
-               WHERE ch_st.plantparent_id = pc.plantconcept_id
+               WHERE ch_st.plantparent_id = pc.plantconcept_id{
+                     and_child_status}
             ) children ON true
             LEFT JOIN LATERAL (
               SELECT JSON_AGG(JSON_BUILD_OBJECT(
@@ -142,46 +191,6 @@ class PlantConcept(Operator):
             ORDER BY COALESCE(pc.d_obscount, 0) {self.direction},
                      pc.plantconcept_id {self.direction}
             """
-
-        if self.request.args.get('status') == 'current':
-            always_condition = {
-                'sql': """\
-                    EXISTS (
-                        SELECT plantconcept_id
-                          FROM plantstatus ps
-                          WHERE pc.plantconcept_id = ps.plantconcept_id
-                            AND ps.stopdate IS NULL)
-                    """,
-                'params': []
-            }
-        elif self.request.args.get('status') == 'accepted':
-            always_condition = {
-                'sql': """\
-                    EXISTS (
-                        SELECT plantconcept_id
-                          FROM plantstatus ps
-                          WHERE pc.plantconcept_id = ps.plantconcept_id
-                            AND ps.plantconceptstatus LIKE 'accepted%%')
-                    """,
-                'params': []
-            }
-        elif self.request.args.get('status') == 'current_accepted':
-            always_condition = {
-                'sql': """\
-                    EXISTS (
-                        SELECT plantconcept_id
-                          FROM plantstatus ps
-                          WHERE pc.plantconcept_id = ps.plantconcept_id
-                            AND ps.plantconceptstatus LIKE 'accepted%%'
-                            AND ps.stopdate IS NULL)
-                    """,
-                'params': []
-            }
-        else:
-            always_condition = {
-                'sql': None,
-                'params': []
-            }
 
         self.query = {}
         self.query['base'] = {


### PR DESCRIPTION
### What

This PR extends the `status` parameter used in `GET /plant-concepts` and `GET /community-concepts` to apply to returned children (nested array field) as well.

### Why

VegBank has cases where newer (current) and older (no longer current) concept records point to the same taxonomic parent. When the parent concept is returned by the API with nested fields included, all of its children are returned. This can be confusing if the client has obtained that concept with e.g. `status=current`. Under this PR, that's no longer the case -- children will be also respect the status criterion.

### How

Enhanced the SQL generation logic as needed in the concept operators.

### Testing & documentation

Manually tested and updated the OpenAPI Spec doc.

### Demo

##### Old behavior

Concept record for order `Asterales` returns 2 `Asteraceae` child listings, one of which is the current family concept record, and one of which is an obsolete (no longer active) record of the same concept.

```sh
http GET 'http://127.0.0.1:8080/plant-concepts/pc.92308?with_nested=true' \
    | jq ".data[] | {pc_code, plant_name, children}"
```
```json
{
  "pc_code": "pc.92308",
  "plant_name": "Asterales",
  "children": [
    {
      "pc_code": "pc.91507",
      "plant_name": "Asteraceae"
    },
    {
      "pc_code": "pc.2087117",
      "plant_name": "Asteraceae"
    }
  ]
}
```
##### New behavior

With `status=current`, only the current child family is returned.

```sh
http GET 'http://127.0.0.1:8080/plant-concepts/pc.92308?with_nested=true&status=current' \
    | jq ".data[] | {pc_code, plant_name, children}"
```
```json
{
  "pc_code": "pc.92308",
  "plant_name": "Asterales",
  "children": [
    {
      "pc_code": "pc.2087117",
      "plant_name": "Asteraceae"
    }
  ]
}
```
