### PR TITLE
Include vb codes in search

### DIFF
--- a/src/vegbank/operators/CommunityConcept.py
+++ b/src/vegbank/operators/CommunityConcept.py
@@ -213,9 +213,14 @@ class CommunityConcept(Operator):
                 'always': always_condition,
                 'search': {
                     'sql': """\
-                         cc.search_vector @@ WEBSEARCH_TO_TSQUERY('simple', %s)
+                         (cc.search_vector @@ WEBSEARCH_TO_TSQUERY('simple', %s)
+                          OR cc.commconcept_id = CASE
+                              WHEN %s ~ '^cc\.\d+$'
+                              THEN regexp_replace(%s, '^cc\.', '')::integer
+                              ELSE NULL
+                            END)
                     """,
-                    'params': ['search']
+                    'params': ['search', 'search', 'search']
                 },
                 "cc": {
                     'sql': "cc.commconcept_id = %s",

--- a/src/vegbank/operators/Party.py
+++ b/src/vegbank/operators/Party.py
@@ -87,9 +87,14 @@ class Party(Operator):
                 },
                 'search': {
                     'sql': """\
-                         py.search_vector @@ WEBSEARCH_TO_TSQUERY('simple', %s)
+                         (py.search_vector @@ WEBSEARCH_TO_TSQUERY('simple', %s)
+                          OR py.party_id = CASE
+                              WHEN %s ~ '^py\.\d+$'
+                              THEN regexp_replace(%s, '^py\.', '')::integer
+                              ELSE NULL
+                            END)
                     """,
-                    'params': ['search']
+                    'params': ['search', 'search', 'search']
                 },
                 "py": {
                     'sql': "py.party_id = %s",

--- a/src/vegbank/operators/PlantConcept.py
+++ b/src/vegbank/operators/PlantConcept.py
@@ -213,9 +213,14 @@ class PlantConcept(Operator):
                 'always': always_condition,
                 'search': {
                     'sql': """\
-                         pc.search_vector @@ WEBSEARCH_TO_TSQUERY('simple', %s)
+                         (pc.search_vector @@ WEBSEARCH_TO_TSQUERY('simple', %s)
+                          OR pc.plantconcept_id = CASE
+                              WHEN %s ~ '^pc\.\d+$'
+                              THEN regexp_replace(%s, '^pc\.', '')::integer
+                              ELSE NULL
+                            END)
                     """,
-                    'params': ['search']
+                    'params': ['search', 'search', 'search']
                 },
                 "pc": {
                     'sql': "pc.plantconcept_id = %s",

--- a/src/vegbank/operators/PlotObservation.py
+++ b/src/vegbank/operators/PlotObservation.py
@@ -454,9 +454,14 @@ class PlotObservation(Operator):
                 },
                 'search': {
                     'sql': """\
-                         ob.search_vector @@ WEBSEARCH_TO_TSQUERY('simple', %s)
+                         (ob.search_vector @@ WEBSEARCH_TO_TSQUERY('simple', %s)
+                          OR ob.observation_id = CASE
+                              WHEN %s ~ '^ob\.\d+$'
+                              THEN regexp_replace(%s, '^ob\.', '')::integer
+                              ELSE NULL
+                            END)
                     """,
-                    'params': ['search']
+                    'params': ['search', 'search', 'search']
                 },
                 'ob': {
                     'sql': "ob.observation_id = %s",

--- a/src/vegbank/operators/Project.py
+++ b/src/vegbank/operators/Project.py
@@ -92,9 +92,14 @@ class Project(Operator):
                 },
                 'search': {
                     'sql': """\
-                         pj.search_vector @@ WEBSEARCH_TO_TSQUERY('simple', %s)
+                         (pj.search_vector @@ WEBSEARCH_TO_TSQUERY('simple', %s)
+                          OR pj.project_id = CASE
+                              WHEN %s ~ '^pj\.\d+$'
+                              THEN regexp_replace(%s, '^pj\.', '')::integer
+                              ELSE NULL
+                            END)
                     """,
-                    'params': ['search']
+                    'params': ['search', 'search', 'search']
                 },
                 "pj": {
                     'sql': "pj.project_id = %s",


### PR DESCRIPTION
### What

This PR makes it so that the `search` query parameter in relevant `GET` requests will retrieve a record by its vb code (e.g., `ob.123`) when that vb code is given as the search text.

Applicable resources:
- Plot observations
- Plant concepts
- Community concepts
- Projects
- Parties

### Why

So that we have unified search over the existing search terms __*and*__ vb codes.

Note that if a client _knows_ they have a vb code, they can (and probably should) use `GET /plot-observations/ob.123` to get the resource by its code more directly. However, the change here helps create a more unified interface for convenience.

### How

Extended the search SQL to not only do full text search for a term, but also parse the term as if it were a vb code of the relevant type, and try to retrieve the item that way.

### Testing

Tested manually, and also locally used R to verify equivalence of results between records returned by search and by direct access. See demo.

### Demo

##### Show that the same concepts are returned by code vs (new) code-based search:

```sh
$ http GET 'http://127.0.0.1:8080/plot-observations/ob.79459?detail=geo'
```
```json
{
    "count": 1,
    "data": [
        {
            "author_obs_code": "016-01-0047",
            "latitude": 32.042011478,
            "longitude": -81.805401741,
            "ob_code": "ob.79459"
        }
    ]
}
```
```sh
$ http GET 'http://127.0.0.1:8080/plot-observations?search=ob.79459&detail=geo'
```
```json
{
    "count": 1,
    "data": [
        {
            "author_obs_code": "016-01-0047",
            "latitude": 32.042011478,
            "longitude": -81.805401741,
            "ob_code": "ob.79459",
            "search_rank": 0.0
        }
    ]
}
```

##### Equivalence testing in R

```
# check that plot observation search for ob code works
expect_identical(
    vb_get_plot_observations("ob.41618", parquet=TRUE),
    vb_get_plot_observations(search="ob.41618", detail="full",
                             with_nested=TRUE, num_taxa=1000) |>
      dplyr::select(-search_rank))

# check that plant concept search for pc code works
expect_identical(
    vb_get_plant_concepts("pc.193", parquet=TRUE),
    vb_get_plant_concepts(search="pc.193", detail="full", with_nested=TRUE) |>
      dplyr::select(-search_rank))

# check that community concept search for cc code works
expect_identical(
    vb_get_community_concepts("cc.30617", parquet=TRUE),
    vb_get_community_concepts(search="cc.30617", detail="full",
                              with_nested=TRUE) |>
      dplyr::select(-search_rank))

# verify that project search for pj code works
testthat::expect_identical(
    vb_get_projects("pj.10508", parquet=TRUE),
    vb_get_projects(search="pj.10508", detail="full") |>
      dplyr::select(-search_rank))

# check that party search for py code works
expect_identical(
    vb_get_parties("py.191378", parquet=TRUE),
    vb_get_parties(search="py.191378", detail="full") |>
      dplyr::select(-search_rank))
```