### PR TITLE
add nginx annotations to allow large uploads (copied from metacat)

### DIFF
--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -125,9 +125,6 @@ ingress:
   enabled: true
   ## @param ingress.className The class of the ingress controller to use.
   className: nginx
-  annotations:
-    ## @param ingress.annotations.cert-manager.io/cluster-issuer
-    cert-manager.io/cluster-issuer: "letsencrypt-prod" 
   hosts:
     ## @param ingress.hosts[0].host The host names for the ingress.
     - host: api-dev.vegbank.org
@@ -143,6 +140,65 @@ ingress:
         - api-dev.vegbank.org 
       ## @param ingress.tls[0].secretName The name of the secret containing the TLS certificate.
       secretName: ingress-nginx-tls-cert 
+  annotations:
+    ## @param ingress.annotations.cert-manager.io/cluster-issuer
+    cert-manager.io/cluster-issuer: "letsencrypt-prod"
+
+    ## @skip ingress.annotations.nginx.ingress.kubernetes.io/client-body-buffer-size See docs:
+    ## https://nginx.org/en/docs/http/ngx_http_core_module.html#client_body_buffer_size
+    ##
+    nginx.ingress.kubernetes.io/client-body-buffer-size: "1m"
+
+    ## @skip ingress.annotations.nginx.ingress.kubernetes.io/client_max_body_size See docs:
+    ## https://nginx.org/en/docs/http/ngx_http_core_module.html#client_max_body_size
+    ## Sets the maximum allowed size of the client request body. Setting to 0 disables checking of
+    ## client request body size
+    ##
+    nginx.ingress.kubernetes.io/client_max_body_size: "0"
+
+    ## @skip ingress.annotations.nginx.ingress.kubernetes.io/send-timeout See docs:
+    ## https://nginx.org/en/docs/http/ngx_http_core_module.html#send_timeout
+    ## Sets a timeout for transmitting a response to the client. The timeout is set only between
+    ## two successive write operations, not for the transmission of the whole response. If the
+    ## client does not receive anything within this time, the connection is closed. Default is 60s,
+    ## but we set it to 3600 seconds to prevent 504 Gateway Time-out when downloading zip files of
+    ## huge datasets using bagit
+    ##
+    nginx.ingress.kubernetes.io/send-timeout: "3600"
+
+    ## @skip ingress.annotations.nginx.ingress.kubernetes.io/proxy-body-size See docs:
+    ## https://github.com/kubernetes/ingress-nginx/blob/main/docs/user-guide/nginx-configuration/configmap.md#proxy-body-size
+    ## Sets the maximum allowed size of the client request body - similar to the nginx
+    ## client_max_body_size directive. Setting to 0 disables checking of client request body size
+    ##
+    nginx.ingress.kubernetes.io/proxy-body-size: "0"
+
+    ## @skip ingress.annotations.nginx.ingress.kubernetes.io/proxy-read-timeout See docs:
+    ## https://nginx.org/en/docs/http/ngx_http_proxy_module.html#proxy_read_timeout
+    ## default is 60 seconds, but we set it to 3600 seconds to prevent 504 Gateway Time-out when
+    ## downloading zip files of huge datasets using bagit
+    ##
+    nginx.ingress.kubernetes.io/proxy-read-timeout: "3600"
+
+    ## @skip ingress.annotations.nginx.ingress.kubernetes.io/proxy-send-timeout See docs:
+    ## https://nginx.org/en/docs/http/ngx_http_proxy_module.html#proxy_send_timeout
+    ## The timeout is set only between two successive write operations, not for the transmission of
+    ## the whole request. We set it to 3600 seconds to prevent 504 Gateway Time-out when
+    ## downloading zip files of huge datasets using bagit
+    ##
+    nginx.ingress.kubernetes.io/proxy-send-timeout: "3600"
+
+    ## @skip ingress.annotations.nginx.ingress.kubernetes.io/proxy-request-buffering See docs:
+    ## https://nginx.org/en/docs/http/ngx_http_proxy_module.html#proxy_request_buffering
+    ##
+    nginx.ingress.kubernetes.io/proxy-request-buffering: "off"
+
+    ## @skip ingress.annotations.nginx.ingress.kubernetes.io/proxy-buffering See docs:
+    ## https://nginx.org/en/docs/http/ngx_http_proxy_module.html#proxy_buffering
+    ## According to ingress-nginx docs, default is "off", but according to nginx docs, default is
+    ## "on", so we set it explicitly to "off", be sure
+    ##
+    nginx.ingress.kubernetes.io/proxy-buffering: "off"
 
 ## @param resources
 resources: {}


### PR DESCRIPTION
part of #319 

Add nginx annotations to resolve `413 Request Entity Too Large` and allow large uploads (copied from metacat chart)