### PR TITLE
Implement /refresh endpoint

### DIFF
--- a/helm/docs/api-authorization.md
+++ b/helm/docs/api-authorization.md
@@ -83,7 +83,7 @@ curl -s -L -X POST 'https://api.vegbank.org/refresh' \
   -H "Content-Type: application/json" \
   -d "{
     \"refresh_token\": \"${REFRESH}\",
-    \"scope\": \"openid web-origins acr offline_access profile basic email\"
+    \"scope\": \"openid web-origins acr offline_access profile basic email vegbank:contributor vegbank:user\"
   }"
 ```
 
@@ -92,7 +92,9 @@ curl -s -L -X POST 'https://api.vegbank.org/refresh' \
 | Field | Type | Required | Description |
 |-------|------|----------|-------------|
 | `refresh_token` | string | Yes | The refresh token returned from `/login` or a previous `/refresh` call |
-| `scope` | string | No | Space-separated list of scopes for the new access token. |
+| `scope` | string | No | Space-separated list of scopes for the new access token. If no scopes are provided, the new access token will have the same scopes as the original token. The requested scopes must match or be a subset of the original scopes granted. |
+
+> **Note:** In most cases, you can safely omit the `scope` parameter. The OIDC provider will reissue the token with the same scopes that were originally granted, which is typically the desired behavior. 
 
 #### Response
 
@@ -108,7 +110,7 @@ On success (`200 OK`):
 }
 ```
 
-Replace your stored tokens with the new values returned. Each refresh call issues a **new refresh token**, so the old one should be discarded.
+Replace your stored tokens with the new values returned. Because each refresh token can only be used once, each refresh call issues a new refresh token, and so the old one must be discarded.
 
 **Error responses:**
 

--- a/src/vegbank/auth.py
+++ b/src/vegbank/auth.py
@@ -329,7 +329,7 @@ def require_token(methods=None):
             
             # In read_only or open mode, skip auth entirely
             if mode != ACCESS_MODE_AUTHENTICATED:
-                logger.debug("Access mode '%s': skipping token validation", mode)
+                logger.warning("Access mode '%s': skipping token validation", mode)
                 return f(None, *args, **kwargs)
             
             # If methods are specified, only enforce auth for those methods
@@ -394,7 +394,7 @@ def require_scope(required_scope: str, methods=None):
             
             # In read_only or open mode, skip auth entirely
             if mode != ACCESS_MODE_AUTHENTICATED:
-                logger.debug("Access mode '%s': skipping scope validation", mode)
+                logger.warning("Access mode '%s': skipping scope validation", mode)
                 # Store None in g for consistency
                 g.token_claims = None
                 return f(*args, **kwargs)
@@ -474,7 +474,7 @@ def refresh_token():
 
     Parameters (in JSON body):
     - ``refresh_token`` (string, required): The refresh token issued by the OIDC provider.
-    - ``scope`` (string, optional): Space-separated list of scopes to request for the new access token. If omitted, the new access token will have the same scopes as the original
+    - ``scope`` (string, optional): Space-separated list of scopes to request for the new access token. If omitted, the new access token will have the same scopes as the original token.
 
     Returns:
     200 JSON with new ``access_token`` and ``refresh_token`` on success.
@@ -512,8 +512,6 @@ def refresh_token():
                 refresh_token=user_refresh_token,
                 scope=requested_scope,
             )
-
-        # 3. Return the new tokens (Access + Refresh) as JSON to the frontend
         return _token_response(new_tokens, message="Authorization successful")
     except InvalidGrantError as exc:
         # The refresh token was invalid, expired, or revoked by the provider


### PR DESCRIPTION
Implements a `/refresh` endpoint for OIDC token refresh and improves JWT validation.

- Add `/refresh` endpoint to exchange a refresh token for a new access token
- Update JWT validation to include audience (aud) claim verification
- Remove the already authenticated check that short-circuited the auth flow
- Improve logging levels for token validation and auth errors (rel: #372)
  - `debug`: Expected auth failures and per-request events (e.g. invalid/expired token, rejected refresh). App is working correctly.
  - `info`: Infrequent lifecycle events (e.g. startup, initialization).
  - `warning`: Misconfiguration or environment issues (e.g. missing secrets file, wrong client credentials).
  - `error`: Unexpected failures that indicate a bug, logs related stack trace/
- Update documentation for refresh token support

Rel: #380