### PR TITLE
Improve handling of missing stratum name

### DIFF
--- a/src/vegbank/operators/PlotObservation.py
+++ b/src/vegbank/operators/PlotObservation.py
@@ -350,11 +350,14 @@ class PlotObservation(Operator):
                        txo.int_currplantscinamenoauth,
                        txo.authorplantname,
                        sr.stratum_id,
-                       sr.stratumname,
+                       CASE WHEN sr.stratum_id IS NULL THEN '<All>'
+                            ELSE COALESCE(sr.stratumname, sy.stratumname)
+                        END AS stratumname,
                        tm.cover
                   FROM taxonobservation txo
                   LEFT JOIN taxonimportance tm USING (taxonobservation_id)
                   LEFT JOIN stratum sr USING (stratum_id)
+                  LEFT JOIN stratumtype sy USING (stratumtype_id)
                   WHERE txo.observation_id = ob.observation_id
               ), returned_taxon_observations AS (
                 SELECT *
@@ -371,7 +374,7 @@ class PlotObservation(Operator):
                          'plant_name', COALESCE(int_currplantscinamenoauth,
                                                 authorplantname),
                          'sr_code', 'sr.' || stratum_id,
-                         'stratum_name', COALESCE(stratumname, '-all-'),
+                         'stratum_name', stratumname,
                          'cover', cover
                          )) AS top_taxon_observations
                         FROM returned_taxon_observations) AS top_taxon_observations,

--- a/src/vegbank/operators/StemCount.py
+++ b/src/vegbank/operators/StemCount.py
@@ -1,4 +1,5 @@
 import os
+import textwrap
 from vegbank.operators import Operator
 
 
@@ -29,7 +30,9 @@ class StemCount(Operator):
             'to_code': "'to.' || tm.taxonobservation_id",
             'tm_code': "'tm.' || sc.taxonimportance_id",
             'sr_code': "'sr.' || tm.stratum_id",
-            'stratum_name': "COALESCE(sr.stratumname, '<All>')",
+            'stratum_name': f"({textwrap.dedent("""\
+                CASE WHEN tm.stratum_id IS NULL THEN '<All>'
+                     ELSE COALESCE(sr.stratumname, sy.stratumname) END""")})",
             'sc_code': "'sc.' || sc.stemcount_id",
             'diameter': "sc.stemdiameter",
             'diameter_accuracy': "sc.stemdiameteraccuracy",
@@ -44,6 +47,7 @@ class StemCount(Operator):
             JOIN taxonimportance tm USING (taxonimportance_id)
             JOIN taxonobservation txo USING (taxonobservation_id)
             LEFT JOIN stratum sr USING (stratum_id)
+            LEFT JOIN stratumtype sy USING (stratumtype_id)
             """
         order_by_sql = """\
             ORDER BY sc.stemcount_id

--- a/src/vegbank/operators/TaxonImportance.py
+++ b/src/vegbank/operators/TaxonImportance.py
@@ -1,4 +1,5 @@
 import os
+import textwrap
 from vegbank.operators.operator_parent_class import Operator
 
 
@@ -36,7 +37,9 @@ class TaxonImportance(Operator):
             'to_code': "'to.' || tm.taxonobservation_id",
             'ob_code': "'ob.' || txo.observation_id",
             'sr_code': "'sr.' || tm.stratum_id",
-            'stratum_name': "COALESCE(sr.stratumname, '<All>')",
+            'stratum_name': f"({textwrap.dedent("""\
+                CASE WHEN tm.stratum_id IS NULL THEN '<All>'
+                     ELSE COALESCE(sr.stratumname, sy.stratumname) END""")})",
             'cover': "tm.cover",
             'cover_code': "tm.covercode",
             'basal_area': "tm.basalarea",
@@ -54,6 +57,7 @@ class TaxonImportance(Operator):
             FROM tm
             JOIN taxonobservation txo USING (taxonobservation_id)
             LEFT JOIN stratum sr USING (stratum_id)
+            LEFT JOIN stratumtype sy USING (stratumtype_id)
             """
         from_sql['full_nested'] = from_sql['full'].rstrip() + """
             LEFT JOIN LATERAL (

--- a/src/vegbank/operators/TaxonObservation.py
+++ b/src/vegbank/operators/TaxonObservation.py
@@ -80,8 +80,8 @@ class TaxonObservation(Operator):
             LEFT JOIN LATERAL (
               SELECT JSON_AGG(JSON_BUILD_OBJECT(
                          'tm_code', 'tm.' || taxonimportance_id,
-                         'sm_code', 'sm.' || stratum_id,
-                         'stratum_name', COALESCE(stratumname, '<All>'),
+                         'sr_code', 'sr.' || stratum_id,
+                         'stratum_name', stratumname,
                          'cover', cover,
                          'cover_code', covercode,
                          'basal_area', basalarea,
@@ -99,10 +99,13 @@ class TaxonObservation(Operator):
                          tm.inferencearea,
                          tm.stratumbase,
                          tm.stratumheight,
-                         sr.stratumname,
+                         CASE WHEN tm.stratum_id IS NULL THEN '<All>'
+                              ELSE COALESCE(sr.stratumname, sy.stratumname)
+                          END AS stratumname,
                          sr.stratum_id
                     FROM taxonimportance tm
                     LEFT JOIN stratum sr USING (stratum_id)
+                    LEFT JOIN stratumtype sy USING (stratumtype_id)
                     WHERE tm.taxonobservation_id = txo.taxonobservation_id
                     ORDER BY stratum_id
                 )


### PR DESCRIPTION
### What

This PR fixes errors in `GET` API responses that arise when `stratum.stratumname` is `NULL`. First of all, with respect to taxon importances, this was treated as an indicator of "no stratum assigned", which is imprecise because this should really be based on whether the taxon importance `stratum_id` field is null. Secondly, when `stratumname` is missing from `stratum`, we should try pulling it from `stratumtype` instead.

The solution adopted here is to correctly determine whether an importance record is "across all strata" vs linked to a stratum record, and fully query through to the `stratumtype` table in the latter case.

### Why

Previously, we relied on `stratum.stratumname` always being populated, because historically that was the case. However, in the original system it was populated as a denormalized field that we are no longer maintaining.

### How

Updated SQL to query through to `stratumtype` for all of the following `GET` cases:
- `plot-observations` (needed for the `top_taxon_observation` nested array field)
- `taxon-observations` (needed for the `taxon_importance` nested array field)
- `taxon-importances` (needed for the main query response)
- `stem-counts` (needed for the main query response)

### Testing

Created a manual test case by nullifying the `stratum.stratumname` in one test record in a local test DB instance, and changing its related `stratumtype.stratumname` to **MODULE** to make it clearer that we're grabbing this now.

```sql
begin;
update stratum set stratumname = NULL where stratum_id = 434652;
update stratumtype set stratumname = 'MODULE' where stratumtype_id = 217628;
commit;
```

See results as expected from R:

#### Plot observations -- nested taxon observations field

```
$ vb_get_plot_observations("ob.78727", with_nested=TRUE) %>%
    pull("top_taxon_observations") %>% "[["(1)
    %>% filter(to_code == "to.841929")
```
Old behavior:
```
   cover   pc_code         plant_name   sr_code stratum_name    tm_code   to_code
1     NA pc.110431 Taxodium distichum sr.434652        -all- tm.1104973 to.841929 ## <- INCORRECT
2 17.500 pc.110431 Taxodium distichum sr.434645         Tree tm.1104971 to.841929
3 17.500 pc.110431 Taxodium distichum sr.434650       module tm.1104969 to.841929
4  7.500 pc.110431 Taxodium distichum sr.434649       module tm.1104968 to.841929
5  7.500 pc.110431 Taxodium distichum      <NA>        -all- tm.1104970 to.841929
6  7.500 pc.110431 Taxodium distichum sr.434648       module tm.1104967 to.841929
7  0.505 pc.110431 Taxodium distichum sr.434647         Herb tm.1104972 to.841929

```

New behavior:
```
   cover   pc_code         plant_name   sr_code stratum_name    tm_code   to_code
1     NA pc.110431 Taxodium distichum sr.434652       MODULE tm.1104973 to.841929  ## <- FIXED
2 17.500 pc.110431 Taxodium distichum sr.434645         Tree tm.1104971 to.841929
3 17.500 pc.110431 Taxodium distichum sr.434650       module tm.1104969 to.841929
4  7.500 pc.110431 Taxodium distichum sr.434649       module tm.1104968 to.841929
5  7.500 pc.110431 Taxodium distichum      <NA>        <All> tm.1104970 to.841929
6  7.500 pc.110431 Taxodium distichum sr.434648       module tm.1104967 to.841929
7  0.505 pc.110431 Taxodium distichum sr.434647         Herb tm.1104972 to.841929
```

#### Taxon observations -- nested taxon importance field

(Yes, it's just a coincidence that biomass and cover aren't populated for this particular record). 

```
$ vb_get_taxon_observations("to.841929", detail="full", with_nested=TRUE) %>%
    pull("taxon_importance") %>%  "[["(1)
```
Old behavior:
```
  basal_area biomass  cover cover_code inference_area   sm_code stratum_base stratum_height stratum_name    tm_code
1         NA      NA 17.500          6             NA sm.434645            3           30.0         Tree tm.1104971
2         NA      NA  0.505          2             NA sm.434647            0            0.5         Herb tm.1104972
3         NA      NA  7.500          5             NA sm.434648           NA             NA       module tm.1104967
4         NA      NA  7.500          5             NA sm.434649           NA             NA       module tm.1104968
5         NA      NA 17.500          6             NA sm.434650           NA             NA       module tm.1104969
6         NA      NA     NA       <NA>             NA sm.434652           NA             NA        <All> tm.1104973 ## <- INCORRECT
7         NA      NA  7.500          5             NA      <NA>           NA             NA        <All> tm.1104970
```

New behavior:
```
  basal_area biomass  cover cover_code inference_area   sr_code stratum_base stratum_height stratum_name    tm_code
1         NA      NA 17.500          6             NA sr.434645            3           30.0         Tree tm.1104971
2         NA      NA  0.505          2             NA sr.434647            0            0.5         Herb tm.1104972
3         NA      NA  7.500          5             NA sr.434648           NA             NA       module tm.1104967
4         NA      NA  7.500          5             NA sr.434649           NA             NA       module tm.1104968
5         NA      NA 17.500          6             NA sr.434650           NA             NA       module tm.1104969
6         NA      NA     NA       <NA>             NA sr.434652           NA             NA       MODULE tm.1104973  ## <- FIXED
7         NA      NA  7.500          5             NA      <NA>           NA             NA        <All> tm.1104970
```

#### Taxon importance

```
$  vb_get_taxon_importances("tm.1104973", detail="full", with_nested=FALSE) %>%
    select(ob_code, to_code, tm_code, sr_code, stratum_name)
```

Old behavior:
```
# A tibble: 1 × 5
  ob_code  to_code   tm_code    sr_code   stratum_name
  <chr>    <chr>     <chr>      <chr>     <chr>
1 ob.78727 to.841929 tm.1104973 sr.434652 <All> ## <- INCORRECT

```

New behavior:
```
# A tibble: 1 × 5
  ob_code  to_code   tm_code    sr_code   stratum_name
  <chr>    <chr>     <chr>      <chr>     <chr>
1 ob.78727 to.841929 tm.1104973 sr.434652 MODULE  ## <- FIXED
```

#### Stem counts

```
$ vb_get_stem_counts("tm.1104973") %>% select(ob_code:sc_code)
```

Old behavior:
```
# A tibble: 2 × 6
  ob_code  to_code   tm_code    sr_code   stratum_name sc_code
  <chr>    <chr>     <chr>      <chr>     <chr>        <chr>
1 ob.78727 to.841929 tm.1104973 sr.434652 <All>        sc.83049 ## <- INCORRECT
2 ob.78727 to.841929 tm.1104973 sr.434652 <All>        sc.83050 ## <- INCORRECT

```

New behavior:
```
# A tibble: 2 × 6
  ob_code  to_code   tm_code    sr_code   stratum_name sc_code
  <chr>    <chr>     <chr>      <chr>     <chr>        <chr>
1 ob.78727 to.841929 tm.1104973 sr.434652 MODULE       sc.83049  ## <- FIXED
2 ob.78727 to.841929 tm.1104973 sr.434652 MODULE       sc.83050  ## <- FIXED
```