### PR TITLE
Bug 397: Adding author obs code to all the required field lists

### DIFF
--- a/src/vegbank/operators/PlotObservation.py
+++ b/src/vegbank/operators/PlotObservation.py
@@ -643,8 +643,8 @@ class PlotObservation(Operator):
                           df['vb_pl_code'].notnull()]
 
         table_defs = [table_defs_config.plot, table_defs_config.observation]
-        new_pl_required_fields = ['author_plot_code', 'confidentiality_status', 'user_ob_code', 'vb_pj_code']
-        old_pl_required_fields = ['vb_pl_code', 'user_ob_code', 'vb_pj_code']
+        new_pl_required_fields = ['author_plot_code', 'confidentiality_status', 'user_ob_code', 'author_obs_code', 'vb_pj_code']
+        old_pl_required_fields = ['vb_pl_code', 'user_ob_code', 'author_obs_code' ,'vb_pj_code']
         if not new_plots_df.empty:
             print("found some new plots")
             new_validation = validate_required_and_missing_fields(

--- a/src/vegbank/operators/Validator.py
+++ b/src/vegbank/operators/Validator.py
@@ -52,8 +52,8 @@ config = {
         "xor_fields": [('vb_py_code', 'user_py_code')]
     },
     "plot_observations": {  # This one has different config fields because the required fields depend on whether the observation is on a new plot or an existing plot.
-        "new_pl_required_fields": ['user_pl_code', 'author_plot_code', 'confidentiality_status', 'user_ob_code'],
-        "old_pl_required_fields": ['vb_pl_code', 'user_ob_code'],
+        "new_pl_required_fields": ['user_pl_code', 'author_plot_code', 'confidentiality_status', 'user_ob_code', 'author_obs_code'],
+        "old_pl_required_fields": ['vb_pl_code', 'user_ob_code', 'author_obs_code'],
         "table_defs": [table_defs_config.plot, table_defs_config.observation],
         "xor_fields": [('user_pj_code', 'vb_pj_code'), ('user_pl_code', 'vb_pl_code')]
     }


### PR DESCRIPTION
### What
This PR adds author_obs_code to the two sets of required field lists, both in the validator and plot observation upload method. 

### Why
Even though this field is not required at the database level, it gets used as a label in a number of UI places and is a primary way for people to identify their own observations. 

### Testing
Previous plot observation test files were ran in addition to a new one missing author_obs_code to ensure the error is generated correctly. 