### PR TITLE
Return null max cover records last in top taxa array

### DIFF
--- a/src/vegbank/operators/PlotObservation.py
+++ b/src/vegbank/operators/PlotObservation.py
@@ -325,7 +325,7 @@ class PlotObservation(Operator):
               ), returned_taxa AS (
                 SELECT *
                   FROM all_taxa
-                  ORDER BY maxcover DESC,
+                  ORDER BY maxcover DESC NULLS LAST,
                            authorplantname
                   LIMIT %s
               )


### PR DESCRIPTION
### What

This PR fixes the bug raised [here](https://github.com/NCEAS/vegbank-web/issues/190), whereby the top taxa array in `GET plot-observations` responses lists taxa with `null` max cover values before any others.

### Why

Because the array of top observed taxa by max cover should actually have the top observed taxa by max cover!

### How

Augmented the relevant `ORDER BY` statement with `NULLS LAST`.

### Testing

##### Before the fix

```
$ http GET 'http://127.0.0.1:8080/plot-observations/ob.3312?detail=minimal&with_nested=true&num_taxa=5'
```
```json
{
    "count": 1,
    "data": [
        {
            ...,
            "taxon_count": 19,
            "taxon_count_returned": 5,
            "top_taxon_observations": [
                {
                    "max_cover": null,
                    "name": "Opuntia humifusa",
                    "pc_code": "pc.40983",
                    "to_code": "to.74477"
                },
                {
                    "max_cover": null,
                    "name": "Ratibida columnifera",
                    "pc_code": "pc.48905",
                    "to_code": "to.74480"
                },
                {
                    "max_cover": 15,
                    "name": "Bouteloua gracilis",
                    "pc_code": "pc.13726",
                    "to_code": "to.74467"
                },
                {
                    "max_cover": 15,
                    "name": "Buchloe dactyloides",
                    "pc_code": "pc.14438",
                    "to_code": "to.74469"
                },
                {
                    "max_cover": 15,
                    "name": "Pascopyrum smithii",
                    "pc_code": "pc.42673",
                    "to_code": "to.74478"
                }
            ],
            ...,
        }
    ]
}
```

##### After fix

```
$ http GET 'http://127.0.0.1:8080/plot-observations/ob.3312?detail=minimal&with_nested=true&num_taxa=5'
```
```json
{
    "count": 1,
    "data": [
        {
            ...,
            "taxon_count": 19,
            "taxon_count_returned": 5,
            "top_taxon_observations": [
                {
                    "max_cover": 15,
                    "name": "Bouteloua gracilis",
                    "pc_code": "pc.13726",
                    "to_code": "to.74467"
                },
                {
                    "max_cover": 15,
                    "name": "Buchloe dactyloides",
                    "pc_code": "pc.14438",
                    "to_code": "to.74469"
                },
                {
                    "max_cover": 15,
                    "name": "Pascopyrum smithii",
                    "pc_code": "pc.42673",
                    "to_code": "to.74478"
                },
                {
                    "max_cover": 15,
                    "name": "Sporobolus cryptandrus",
                    "pc_code": "pc.54602",
                    "to_code": "to.74481"
                },
                {
                    "max_cover": 2.5,
                    "name": "Aristida purpurea",
                    "pc_code": "pc.10532",
                    "to_code": "to.74466"
                }
            ],
            ...,
        }
    ]
}
```