### PR TITLE
new flyway migration

### DIFF
--- a/helm/db/migrations/V2.7__change_varchar_to_text.sql
+++ b/helm/db/migrations/V2.7__change_varchar_to_text.sql
@@ -582,7 +582,7 @@ ANALYZE "public"."usr";
 --
 -- COPIED VERBATIM FROM helm/db/migrations/V1.4__create_vegbank_views.sql
 --
-CREATE VIEW view_party_public AS
+CREATE OR REPLACE VIEW view_party_public AS
 SELECT party.party_id,
        accessioncode,
        salutation,
@@ -597,7 +597,7 @@ FROM party
 WHERE usr.usr_id is NULL
    OR usr.permission_type > 1;
 DROP VIEW IF EXISTS view_busRule_plotsizeshape;
-CREATE VIEW view_busRule_plotsizeshape AS
+CREATE OR REPLACE VIEW view_busRule_plotsizeshape AS
 SELECT (project_id),
        (
            select projectName
@@ -619,7 +619,7 @@ where (
           )
 group by project_ID;
 DROP VIEW IF EXISTS view_busRule_duplStratumType;
-CREATE VIEW view_busRule_duplStratumType AS
+CREATE OR REPLACE VIEW view_busRule_duplStratumType AS
 SELECT count(1),
        stratummethod_id,
        stratumindex
@@ -628,7 +628,7 @@ GROUP BY stratummethod_id,
          stratumindex
 HAVING count(1) > 1;
 DROP VIEW IF EXISTS view_busRule_duplcovercode;
-CREATE VIEW view_busRule_duplcovercode AS
+CREATE OR REPLACE VIEW view_busRule_duplcovercode AS
 SELECT count(1),
        covermethod_id,
        covercode
@@ -639,7 +639,7 @@ HAVING count(1) > 1;
 -- EMBARGO views
 DROP VIEW IF EXISTS view_emb_embargo_complete;
 DROP VIEW IF EXISTS view_emb_embargo_currentfullonly;
-CREATE VIEW view_emb_embargo_currentfullonly AS
+CREATE OR REPLACE VIEW view_emb_embargo_currentfullonly AS
 SELECT *
 FROM embargo
 WHERE (
@@ -647,88 +647,88 @@ WHERE (
               AND ((embargoStart) < Now())
               AND ((embargoStop) > Now())
           );
-CREATE VIEW view_emb_embargo_complete AS
+CREATE OR REPLACE VIEW view_emb_embargo_complete AS
 SELECT Coalesce(emb.defaultStatus, 0) AS currentEmb,
        plot.plot_id
 FROM plot
          LEFT JOIN view_emb_embargo_currentfullonly AS emb ON plot.PLOT_ID = emb.plot_ID;
-CREATE VIEW view_notEmb_classContributor AS
+CREATE OR REPLACE VIEW view_notEmb_classContributor AS
 SELECT *
 FROM classContributor
 where emb_classContributor < 6;
-CREATE VIEW view_notEmb_commClass AS
+CREATE OR REPLACE VIEW view_notEmb_commClass AS
 SELECT *
 FROM commClass
 where emb_commClass < 6;
-CREATE VIEW view_notEmb_commInterpretation AS
+CREATE OR REPLACE VIEW view_notEmb_commInterpretation AS
 SELECT *
 FROM commInterpretation
 where emb_commInterpretation < 6;
-CREATE VIEW view_notEmb_disturbanceObs AS
+CREATE OR REPLACE VIEW view_notEmb_disturbanceObs AS
 SELECT *
 FROM disturbanceObs
 where emb_disturbanceObs < 6;
-CREATE VIEW view_notEmb_observation AS
+CREATE OR REPLACE VIEW view_notEmb_observation AS
 SELECT *
 FROM observation
 where emb_observation < 6;
-CREATE VIEW view_notEmb_observationContributor AS
+CREATE OR REPLACE VIEW view_notEmb_observationContributor AS
 SELECT observationContributor.*
 FROM observationContributor
          inner join observation on observationContributor.observation_ID = observation.observation_ID
 where observation.emb_observation < 6;
-CREATE VIEW view_notEmb_plot AS
+CREATE OR REPLACE VIEW view_notEmb_plot AS
 SELECT *
 FROM plot
 where emb_plot < 6;
-CREATE VIEW view_notEmb_soilObs AS
+CREATE OR REPLACE VIEW view_notEmb_soilObs AS
 SELECT *
 FROM soilObs
 where emb_soilObs < 6;
-CREATE VIEW view_notEmb_stemCount AS
+CREATE OR REPLACE VIEW view_notEmb_stemCount AS
 SELECT *
 FROM stemCount
 where emb_stemCount < 6;
-CREATE VIEW view_notEmb_stemLocation AS
+CREATE OR REPLACE VIEW view_notEmb_stemLocation AS
 SELECT *
 FROM stemLocation
 where emb_stemLocation < 6;
-CREATE VIEW view_notEmb_taxonAlt AS
+CREATE OR REPLACE VIEW view_notEmb_taxonAlt AS
 SELECT *
 FROM taxonAlt
 where emb_taxonAlt < 6;
-CREATE VIEW view_notEmb_taxonImportance AS
+CREATE OR REPLACE VIEW view_notEmb_taxonImportance AS
 SELECT *
 FROM taxonImportance
 where emb_taxonImportance < 6;
-CREATE VIEW view_notEmb_taxonInterpretation AS
+CREATE OR REPLACE VIEW view_notEmb_taxonInterpretation AS
 SELECT *
 FROM taxonInterpretation
 where emb_taxonInterpretation < 6;
-CREATE VIEW view_notEmb_taxonObservation AS
+CREATE OR REPLACE VIEW view_notEmb_taxonObservation AS
 SELECT *
 FROM taxonObservation
 where emb_taxonObservation < 6;
-CREATE VIEW view_export_classContributor AS
+CREATE OR REPLACE VIEW view_export_classContributor AS
 SELECT *
 FROM view_notemb_classContributor;
-CREATE VIEW view_export_commClass AS
+CREATE OR REPLACE VIEW view_export_commClass AS
 SELECT *
 FROM view_notemb_commClass;
-CREATE VIEW view_export_commInterpretation AS
+CREATE OR REPLACE VIEW view_export_commInterpretation AS
 SELECT *
 FROM view_notemb_commInterpretation;
-CREATE VIEW view_export_disturbanceObs AS
+CREATE OR REPLACE VIEW view_export_disturbanceObs AS
 SELECT *
 FROM view_notemb_disturbanceObs;
-CREATE VIEW view_export_observation AS
+CREATE OR REPLACE VIEW view_export_observation AS
 SELECT *
 FROM view_notemb_observation;
-CREATE VIEW view_export_observationcontributor AS
+CREATE OR REPLACE VIEW view_export_observationcontributor AS
 SELECT *
 FROM view_notemb_observationcontributor;
 -- PLOT requires shifting field names to remove some fields for confidential plots
-CREATE VIEW view_export_plot_pre AS
+CREATE OR REPLACE VIEW view_export_plot_pre AS
 SELECT plot_id,
        authorplotcode,
        reference_id,
@@ -779,7 +779,7 @@ SELECT plot_id,
        plotrationalenarrative,
        accessioncode
 FROM view_notemb_plot;
-CREATE VIEW view_export_plot AS
+CREATE OR REPLACE VIEW view_export_plot AS
 SELECT plot_id,
        authorplotcode,
        reference_id,
@@ -824,31 +824,31 @@ SELECT plot_id,
        plotrationalenarrative,
        accessioncode
 FROM view_export_plot_pre;
-CREATE VIEW view_export_soilObs AS
+CREATE OR REPLACE VIEW view_export_soilObs AS
 SELECT *
 FROM view_notemb_soilObs;
-CREATE VIEW view_export_stemCount AS
+CREATE OR REPLACE VIEW view_export_stemCount AS
 SELECT *
 FROM view_notemb_stemCount;
-CREATE VIEW view_export_stemLocation AS
+CREATE OR REPLACE VIEW view_export_stemLocation AS
 SELECT *
 FROM view_notemb_stemLocation;
-CREATE VIEW view_export_taxonAlt AS
+CREATE OR REPLACE VIEW view_export_taxonAlt AS
 SELECT *
 FROM view_notemb_taxonAlt;
-CREATE VIEW view_export_taxonImportance AS
+CREATE OR REPLACE VIEW view_export_taxonImportance AS
 SELECT *
 FROM view_notemb_taxonImportance;
-CREATE VIEW view_export_taxonInterpretation AS
+CREATE OR REPLACE VIEW view_export_taxonInterpretation AS
 SELECT *
 FROM view_notemb_taxonInterpretation;
-CREATE VIEW view_export_taxonObservation AS
+CREATE OR REPLACE VIEW view_export_taxonObservation AS
 SELECT *
 FROM view_notemb_taxonObservation;
 ------------------
 -- END EMBARGO VIEWS
 -------------------
-CREATE VIEW view_reference_transl AS
+CREATE OR REPLACE VIEW view_reference_transl AS
 SELECT CASE
            WHEN shortName IS NULL THEN CASE
                                            WHEN title IS NULL THEN CASE
@@ -864,7 +864,7 @@ SELECT CASE
            END AS reference_id_transl,
        reference_id
 from reference;
-CREATE VIEW view_plantconcept_transl AS
+CREATE OR REPLACE VIEW view_plantconcept_transl AS
 SELECT plantconcept_id,
        plantname_id,
        plantname,
@@ -875,7 +875,7 @@ SELECT plantconcept_id,
            where view_reference_transl.reference_id = plantconcept.reference_id
        ) || ']' as plantconcept_id_transl
 FROM plantconcept;
-CREATE VIEW view_commconcept_transl AS
+CREATE OR REPLACE VIEW view_commconcept_transl AS
 SELECT commconcept_id,
        commname_id,
        commname,
@@ -886,7 +886,7 @@ SELECT commconcept_id,
            where view_reference_transl.reference_id = commconcept.reference_id
        ) || ']' as commconcept_id_transl
 FROM commconcept;
-CREATE VIEW view_party_transl AS
+CREATE OR REPLACE VIEW view_party_transl AS
 SELECT CASE
            WHEN surname is null THEN CASE
                                          WHEN organizationname IS NULL THEN '[poorly documented party]'
@@ -900,14 +900,14 @@ SELECT CASE
        party_id
 FROM party;
 --- browsing by party views: -----
-CREATE VIEW view_browseparty_obscontrib AS
+CREATE OR REPLACE VIEW view_browseparty_obscontrib AS
 SELECT observationContributor.PARTY_ID,
        observationContributor.OBSERVATION_ID
 FROM view_notemb_observation as observation
          INNER JOIN observationContributor ON observation.OBSERVATION_ID = observationContributor.OBSERVATION_ID
 GROUP BY observationContributor.PARTY_ID,
          observationContributor.OBSERVATION_ID;
-CREATE VIEW view_browseparty_projectcontrib AS
+CREATE OR REPLACE VIEW view_browseparty_projectcontrib AS
 SELECT observation_1.OBSERVATION_ID,
        projectContributor.PARTY_ID
 FROM (
@@ -917,7 +917,7 @@ FROM (
          INNER JOIN projectContributor ON project.PROJECT_ID = projectContributor.PROJECT_ID
 GROUP BY observation_1.OBSERVATION_ID,
          projectContributor.PARTY_ID;
-CREATE VIEW view_browseparty_classcontrib AS
+CREATE OR REPLACE VIEW view_browseparty_classcontrib AS
 SELECT observation_2.OBSERVATION_ID,
        classContributor.PARTY_ID
 FROM view_notemb_observation AS observation_2
@@ -927,7 +927,7 @@ FROM view_notemb_observation AS observation_2
 ) ON observation_2.OBSERVATION_ID = commClass.OBSERVATION_ID
 GROUP BY observation_2.OBSERVATION_ID,
          classContributor.PARTY_ID;
-CREATE VIEW view_browseparty_all AS
+CREATE OR REPLACE VIEW view_browseparty_all AS
 SELECT OBSERVATION_ID,
        PARTY_ID
 FROM view_browseparty_classcontrib
@@ -939,27 +939,27 @@ UNION
 SELECT OBSERVATION_ID,
        PARTY_ID
 FROM view_browseparty_obscontrib;
-CREATE VIEW view_browseparty_all_count AS
+CREATE OR REPLACE VIEW view_browseparty_all_count AS
 SELECT count(1) AS countallcontrib,
        party_ID
 FROM view_browseparty_all
 GROUP BY party_ID;
-CREATE VIEW view_browseparty_classcontrib_count AS
+CREATE OR REPLACE VIEW view_browseparty_classcontrib_count AS
 SELECT count(1) AS countclasscontrib,
        party_ID
 FROM view_browseparty_classcontrib
 GROUP BY party_ID;
-CREATE VIEW view_browseparty_obscontrib_count AS
+CREATE OR REPLACE VIEW view_browseparty_obscontrib_count AS
 SELECT count(1) AS countobscontrib,
        party_ID
 FROM view_browseparty_obscontrib
 GROUP BY party_ID;
-CREATE VIEW view_browseparty_projectcontrib_count AS
+CREATE OR REPLACE VIEW view_browseparty_projectcontrib_count AS
 SELECT count(1) AS countprojectcontrib,
        party_ID
 FROM view_browseparty_projectcontrib
 GROUP BY party_ID;
-CREATE VIEW view_browseparty_all_count_combined AS
+CREATE OR REPLACE VIEW view_browseparty_all_count_combined AS
 SELECT view_browseparty_all_count.party_ID,
        view_browseparty_all_count.countallcontrib,
        view_browseparty_classcontrib_count.countclasscontrib,
@@ -974,7 +974,7 @@ FROM (
          )
          LEFT JOIN view_browseparty_projectcontrib_count ON view_browseparty_all_count.party_ID = view_browseparty_projectcontrib_count.party_ID
 ORDER BY countallcontrib DESC;
-CREATE view view_csv_taxonimportance_pre AS
+CREATE OR REPLACE VIEW view_csv_taxonimportance_pre AS
 SELECT taxonobservation.observation_id AS observation_ID,
        authorplantname AS plant,
        (
@@ -1012,7 +1012,7 @@ FROM taxonobservation,
      view_notemb_observation AS observation
 WHERE taxonobservation.taxonobservation_id = taxonimportance.taxonobservation_id
   AND taxonobservation.observation_ID = observation.observation_ID;
-CREATE view view_csv_taxonimportance AS
+CREATE OR REPLACE VIEW view_csv_taxonimportance AS
 SELECT observation_ID,
        plant,
        stratum,
@@ -1026,7 +1026,7 @@ SELECT observation_ID,
 FROM view_csv_taxonimportance_pre;
 -- the following views create "standard" names for plantconcepts, based on usages of preferred party and classsystems:
 DROP VIEW IF EXISTS view_std_plantnames_code;
-CREATE VIEW view_std_plantnames_code AS
+CREATE OR REPLACE VIEW view_std_plantnames_code AS
 SELECT plantconcept_id,
        plantname
 FROM plantusage
@@ -1038,7 +1038,7 @@ WHERE classsystem = 'Code'
 )
   AND usagestop IS NULL;
 DROP VIEW IF EXISTS view_std_plantnames_sciname;
-CREATE VIEW view_std_plantnames_sciname AS
+CREATE OR REPLACE VIEW view_std_plantnames_sciname AS
 SELECT plantconcept_id,
        plantname
 FROM plantusage
@@ -1050,7 +1050,7 @@ WHERE classsystem = 'Scientific'
 )
   AND usagestop IS NULL;
 DROP VIEW IF EXISTS view_std_plantnames_scinamenoauth;
-CREATE VIEW view_std_plantnames_scinamenoauth AS
+CREATE OR REPLACE VIEW view_std_plantnames_scinamenoauth AS
 SELECT plantconcept_id,
        plantname
 FROM plantusage
@@ -1062,7 +1062,7 @@ WHERE classsystem = 'Scientific without authors'
 )
   AND usagestop IS NULL;
 DROP VIEW IF EXISTS view_std_plantnames_common;
-CREATE VIEW view_std_plantnames_common AS
+CREATE OR REPLACE VIEW view_std_plantnames_common AS
 SELECT plantconcept_id,
        plantname
 FROM plantusage
@@ -1075,32 +1075,32 @@ WHERE classsystem = 'English Common'
   AND usagestop IS NULL;
 --the following views are same as above, but not party specific, to catch "other concepts":
 DROP VIEW IF EXISTS view_all_plantnames_code;
-CREATE VIEW view_all_plantnames_code AS
+CREATE OR REPLACE VIEW view_all_plantnames_code AS
 SELECT plantconcept_id,
        plantname
 FROM plantusage
 WHERE classsystem = 'Code';
 DROP VIEW IF EXISTS view_all_plantnames_sciname;
-CREATE VIEW view_all_plantnames_sciname AS
+CREATE OR REPLACE VIEW view_all_plantnames_sciname AS
 SELECT plantconcept_id,
        plantname
 FROM plantusage
 WHERE classsystem = 'Scientific';
 DROP VIEW IF EXISTS view_all_plantnames_scinamenoauth;
-CREATE VIEW view_all_plantnames_scinamenoauth AS
+CREATE OR REPLACE VIEW view_all_plantnames_scinamenoauth AS
 SELECT plantconcept_id,
        plantname
 FROM plantusage
 WHERE classsystem = 'Scientific without authors';
 DROP VIEW IF EXISTS view_all_plantnames_common;
-CREATE VIEW view_all_plantnames_common AS
+CREATE OR REPLACE VIEW view_all_plantnames_common AS
 SELECT plantconcept_id,
        plantname
 FROM plantusage
 WHERE classsystem = 'English Common';
 -- the following views create "standard" names for commconcepts, based on usages of preferred party and classsystems:
 DROP VIEW IF EXISTS view_std_commnames_code;
-CREATE VIEW view_std_commnames_code AS
+CREATE OR REPLACE VIEW view_std_commnames_code AS
 SELECT commconcept_id,
        commname
 FROM commusage
@@ -1112,7 +1112,7 @@ WHERE classsystem = 'Code'
 )
   AND usagestop IS NULL;
 DROP VIEW IF EXISTS view_std_commnames_sciname;
-CREATE VIEW view_std_commnames_sciname AS
+CREATE OR REPLACE VIEW view_std_commnames_sciname AS
 SELECT commconcept_id,
        commname
 FROM commusage
@@ -1124,7 +1124,7 @@ WHERE classsystem = 'Scientific'
 )
   AND usagestop IS NULL;
 DROP VIEW IF EXISTS view_std_commnames_translated;
-CREATE VIEW view_std_commnames_translated AS
+CREATE OR REPLACE VIEW view_std_commnames_translated AS
 SELECT commconcept_id,
        commname
 FROM commusage
@@ -1136,7 +1136,7 @@ WHERE classsystem = 'Translated'
 )
   AND usagestop IS NULL;
 DROP VIEW IF EXISTS view_std_commnames_common;
-CREATE VIEW view_std_commnames_common AS
+CREATE OR REPLACE VIEW view_std_commnames_common AS
 SELECT commconcept_id,
        commname
 FROM commusage
@@ -1148,30 +1148,30 @@ WHERE classsystem = 'Common'
 )
   AND usagestop IS NULL;
 DROP VIEW IF EXISTS view_all_commnames_code;
-CREATE VIEW view_all_commnames_code AS
+CREATE OR REPLACE VIEW view_all_commnames_code AS
 SELECT commconcept_id,
        commname
 FROM commusage
 WHERE classsystem = 'Code';
 DROP VIEW IF EXISTS view_all_commnames_sciname;
-CREATE VIEW view_all_commnames_sciname AS
+CREATE OR REPLACE VIEW view_all_commnames_sciname AS
 SELECT commconcept_id,
        commname
 FROM commusage
 WHERE classsystem = 'Scientific';
 DROP VIEW IF EXISTS view_all_commnames_translated;
-CREATE VIEW view_all_commnames_translated AS
+CREATE OR REPLACE VIEW view_all_commnames_translated AS
 SELECT commconcept_id,
        commname
 FROM commusage
 WHERE classsystem = 'Translated';
 DROP VIEW IF EXISTS view_all_commnames_common;
-CREATE VIEW view_all_commnames_common AS
+CREATE OR REPLACE VIEW view_all_commnames_common AS
 SELECT commconcept_id,
        commname
 FROM commusage
 WHERE classsystem = 'Common';
-CREATE VIEW view_comminterp_more AS
+CREATE OR REPLACE VIEW view_comminterp_more AS
 SELECT commClass.observation_ID,
        inspection,
        tableanalysis,
@@ -1204,7 +1204,7 @@ SELECT commClass.observation_ID,
 FROM view_notemb_commClass as commclass,
      comminterpretation
 WHERE commclass.commclass_ID = comminterpretation.commclass_ID;
-CREATE VIEW view_taxonInterp_more AS
+CREATE OR REPLACE VIEW view_taxonInterp_more AS
 SELECT taxonInterpretation.*,
        plantconcept.accessionCode AS pc_accessioncode,
        plantconcept.plantname as pc_plantname,
@@ -1214,16 +1214,16 @@ FROM view_notEmb_taxonInterpretation as taxonInterpretation,
      plantconcept
 WHERE taxonobservation.taxonobservation_ID = taxonInterpretation.taxonobservation_ID
   AND plantconcept.plantconcept_id = taxonInterpretation.plantconcept_id;
-CREATE VIEW view_observation_transl AS
+CREATE OR REPLACE VIEW view_observation_transl AS
 SELECT observation_ID,
        COALESCE(authorObsCode, authorPlotCode) AS observation_id_transl
 FROM view_notemb_observation as observation,
      plot
 WHERE observation.plot_ID = plot.plot_ID;
--- CREATE VIEW view_taxonobs_distinctid_curr AS SELECT observation_id, int_currplantconcept_id as plantconcept_id, max(cover) as maxplantcover FROM view_notEmb_taxonObservation as taxonobservation,     taxonimportance where taxonimportance.taxonobservation_id=taxonobservation.taxonobservation_id GROUP BY plantconcept_id,observation_id;
+-- CREATE OR REPLACE VIEW view_taxonobs_distinctid_curr AS SELECT observation_id, int_currplantconcept_id as plantconcept_id, max(cover) as maxplantcover FROM view_notEmb_taxonObservation as taxonobservation,     taxonimportance where taxonimportance.taxonobservation_id=taxonobservation.taxonobservation_id GROUP BY plantconcept_id,observation_id;
 -- this view needed in the event there are no taxonimportance records for a taxonobservation.
 -- DROP VIEW IF EXISTS view_taxonobs_withmaxcover;
-CREATE VIEW view_taxonobs_withmaxcover AS
+CREATE OR REPLACE VIEW view_taxonobs_withmaxcover AS
 SELECT taxonobservation.*,
        (
            select max(cover)
@@ -1232,7 +1232,7 @@ SELECT taxonobservation.*,
        ) as maxcover
 FROM view_notEmb_taxonObservation as taxonobservation;
 --   DROP VIEW IF EXISTS view_taxonobs_distinctid_curr;
-CREATE VIEW view_taxonobs_distinctid_curr AS
+CREATE OR REPLACE VIEW view_taxonobs_distinctid_curr AS
 SELECT userdataset_id,
        observation_id,
        int_currplantconcept_id as plantconcept_id,
@@ -1245,7 +1245,7 @@ GROUP BY plantconcept_id,
          userdataset_id,
          observation_id;
 -- DROP VIEW IF EXISTS view_taxonobs_distinctid_curr_counts;
-CREATE VIEW view_taxonobs_distinctid_curr_counts AS
+CREATE OR REPLACE VIEW view_taxonobs_distinctid_curr_counts AS
 SELECT userdataset_id,
        plantconcept_id,
        count(1) AS countObs,
@@ -1256,7 +1256,7 @@ FROM view_taxonobs_distinctid_curr
 GROUP BY userdataset_id,
          plantconcept_id;
 -- DROP VIEW IF EXISTS view_taxonobs_distinctid_curr_counts_plants;
-CREATE VIEW view_taxonobs_distinctid_curr_counts_plants AS
+CREATE OR REPLACE VIEW view_taxonobs_distinctid_curr_counts_plants AS
 SELECT view_taxonobs_distinctid_curr_counts.*,
        round(
                CAST (
@@ -1285,7 +1285,7 @@ FROM temptbl_std_plantnames,
      view_taxonobs_distinctid_curr_counts
 WHERE view_taxonobs_distinctid_curr_counts.plantconcept_ID = temptbl_std_plantnames.plantconcept_ID;
 --DROP VIEW IF EXISTS view_plotall_withembargo;
-CREATE VIEW view_plotall_withembargo AS
+CREATE OR REPLACE VIEW view_plotall_withembargo AS
 SELECT plot.*,
        embargo_id,
        embargoreason,
@@ -1300,9 +1300,9 @@ SELECT plot.*,
            ) AS embstatusinclexpired
 from plot
          LEFT JOIN embargo on plot.plot_id = embargo.plot_ID;
---CREATE VIEW view_taxonobs_distinctid_orig;
+--CREATE OR REPLACE VIEW view_taxonobs_distinctid_orig;
 -- KEYWORDS VIEWS (otherwise they just aren't robust enough and are breaking!)
-CREATE VIEW view_kwhelper_refjournal AS
+CREATE OR REPLACE VIEW view_kwhelper_refjournal AS
 SELECT reference.reference_id,
        coalesce(referencejournal.journal, '') || ' ' || coalesce(referencejournal.issn, '') || ' ' || coalesce(referencejournal.abbreviation, '') as kw
 FROM reference,
@@ -1312,7 +1312,7 @@ GROUP BY reference.reference_id,
          referencejournal.journal,
          referencejournal.issn,
          referencejournal.abbreviation;
-CREATE VIEW view_kwhelper_refparty AS
+CREATE OR REPLACE VIEW view_kwhelper_refparty AS
 SELECT reference.reference_id,
        public.CONCAT(
                ' ' || coalesce(referenceparty.givenname, '') || ' ' || coalesce(referenceparty.surname, '') || ' ' || coalesce(referenceparty.suffix, '') || ' ' || coalesce(referenceparty.organizationname, '')
@@ -1323,7 +1323,7 @@ FROM referenceparty,
 WHERE referencecontributor.referenceparty_id = referenceparty.referenceparty_id
   AND reference.reference_id = referencecontributor.reference_id
 GROUP BY reference.reference_id;
-CREATE VIEW view_keywProjPlaces AS
+CREATE OR REPLACE VIEW view_keywProjPlaces AS
 SELECT project.project_id,
        plot.stateProvince
 FROM plot,
@@ -1333,7 +1333,7 @@ WHERE plot.plot_ID = observation.plot_ID
   AND project.project_id = observation.project_id
 GROUP BY project.project_ID,
          plot.stateProvince;
-CREATE VIEW view_kwhelper_projcontrib AS
+CREATE OR REPLACE VIEW view_kwhelper_projcontrib AS
 SELECT project.project_id,
        public.CONCAT(
                ' ' || coalesce(party.givenname, '') || ' ' || coalesce(party.surname, '')
@@ -1344,7 +1344,7 @@ FROM party,
 WHERE party.party_id = projectcontributor.party_Id
   AND project.project_id = projectcontributor.project_id
 GROUP BY project.project_id;
-CREATE VIEW view_dbafielddesc_notimpl AS
+CREATE OR REPLACE VIEW view_dbafielddesc_notimpl AS
 SELECT dba_fielddescription_id,
        tablename,
        (
@@ -1383,12 +1383,12 @@ FROM dba_fielddescription
 WHERE lower(fieldmodel) <> 'implementation'
     and lower(fieldmodel) <> 'denorm'
 ORDER BY dba_fielddescription_id;
-create view stratumtype_x_stratummethod AS
+CREATE OR REPLACE VIEW stratumtype_x_stratummethod AS
 select stratumType.*,
        stratumMethod.accessionCode as sm_accCode
 from stratumType
          inner join stratummethod on stratumType.stratummethod_id = stratummethod.stratummethod_id;
-create view stratumtype_x_observation AS
+CREATE OR REPLACE VIEW stratumtype_x_observation AS
 SELECT stratum.stratum_id,
        stratum.stratumname,
        observation.accessioncode
@@ -1398,13 +1398,13 @@ FROM observation
 --
 -- COPIED VERBATIM FROM helm/db/migrations/V1.8__populate_acc_identifiers_procedure.sql
 --
-CREATE VIEW acc_code_source_map AS
+CREATE OR REPLACE VIEW acc_code_source_map AS
 SELECT * FROM identifiers_source_map WHERE id_type = 'accession_code';
 
 --
 -- COPIED VERBATIM FROM helm/db/migrations/V1.9__populate_vb_identifiers_procedure.sql
 --
-CREATE VIEW vb_code_source_map AS
+CREATE OR REPLACE VIEW vb_code_source_map AS
 SELECT * FROM identifiers_source_map WHERE id_type = 'vb_code';
 
 


### PR DESCRIPTION
see Postgres: Migrate all varchar columns to text type #413 

The plan is:
1. Drop all existing triggers that reference the varchar columns, otherwise PG stops us from modifying the underlying tables; e.g.
   ```shell
   vegbank-apply-flyway Caused by: Failed to execute script 
   V2.7__change_varchar_to_text.sql
   vegbank-apply-flyway ---------------------------------------------------------
   vegbank-apply-flyway SQL State  : 0A000
   vegbank-apply-flyway Error Code : 0
   vegbank-apply-flyway Message    : ERROR: cannot alter type of a column used in
                                     a trigger definition
   ```
2. Drop any existing views that reference the varchar columns, otherwise PG stops us from modifying the underlying tables; e.g.
   ```sql
   ALTER TABLE "public"."commclass" ALTER COLUMN "accessioncode" TYPE text;
   ERROR:  cannot alter type of a column used by a view or rule
   ```
3. Change data types of all 'varchar' columns to 'text' (followed by ANALYZE on each table, to update query planner stats - see be4e9bea8c77759d438ba71ca4d824b6b6c29f6f)
4. Recreate dropped views
5. Recreate any dropped triggers (4055381f11543ba8332a7e57696637a91540405a)

Notes:
- I verified that none of the views have special GRANTS that also need to be recreated
- Flyway automatically wraps each migration in a transaction, so we don't need to do that manually here.
- First time I tested this, it was stuck overnight (14 hours) because the `ALTER TABLE` statements included flyway_schema_history, causing a deadlock. I removed these in 68d54b776e90389521c7eee8c8aacaeff6514127
- Because of the above issue, I decided to set a lock timeout at the beginning of the migration to prevent long waits
- changed `CREATE VIEW` statements from earlier migrations to `CREATE OR REPLACE VIEW` instead, to avoid `ERROR: relation [...] already exists`
