### PR TITLE
Add py_code to user datasets query response

### DIFF
--- a/api/openapi.yml
+++ b/api/openapi.yml
@@ -5827,6 +5827,10 @@ components:
           type: string
           description: "Email address of dataset creator/owner"
           example: "msmith@university.edu"
+        py_code:
+          type: string
+          description: "VegBank party identifier for the dataset creator/owner"
+          example: "py.1"
         obs_count:
           type: integer
           description: "Number of plot observations associated with this dataset"

--- a/src/vegbank/operators/UserDataset.py
+++ b/src/vegbank/operators/UserDataset.py
@@ -38,6 +38,7 @@ class UserDataset(Operator):
             'type': "ds.datasettype",
             'owner_label': "py.party_id_transl",
             'owner_email': "usr.email_address",
+            'py_code': "'py.' || usr.party_id",
             'obs_count':  "(SELECT COUNT(*) FROM userdatasetitem dsi" +
                           " WHERE dsi.userdataset_id = ds.userdataset_id)",
         }


### PR DESCRIPTION
### What

This PR adds `py_code` to the `GET /user-datasets` query response.

### Why

So that clients can link a dataset owner/creator to the corresponding party record.

### How

Updated the relevant SQL snippet.

### Docs & testing

- Updated the OpenAPI Spec doc
- Manually verifed that the field now appears
- Locally updated the R API e2e and integration tests, and confirmed that they pass

### Demo

#### Old behavior

```sh
> http GET 'http://127.0.0.1:8080/user-datasets/ds.203839'
```
```json
{
    "count": 1,
    "data": [
        {
            "accession_code": "VB.ds.196903.6A18087BCB60A9E",
            "description": "some plots in TN",
            "ds_code": "ds.196903",
            "name": "example map 1",
            "obs_count": 7,
            "owner_email": "<some_email_address>",
            "owner_label": "Lee, Michael",
            "start": "Sat, 13 Aug 2005 23:49:13 GMT",
            "stop": null,
            "type": "normal"
        }
    ]
}
```

#### New behavior

```sh
> http GET 'http://127.0.0.1:8080/user-datasets/ds.203839'
```
```json
{
    "count": 1,
    "data": [
        {
            "accession_code": "VB.ds.196903.6A18087BCB60A9E",
            "description": "some plots in TN",
            "ds_code": "ds.196903",
            "name": "example map 1",
            "obs_count": 7,
            "owner_email": "<some_email_address>",
            "owner_label": "Lee, Michael",
            "py_code": "py.410",  <-- NEW FIELD
            "start": "Sat, 13 Aug 2005 23:49:13 GMT",
            "stop": null,
            "type": "normal"
        }
    ]
}
```