### PR TITLE
Feature 430: Don't Add Matched Records as Dataset Items

### DIFF
--- a/src/vegbank/operators/CommunityConcept.py
+++ b/src/vegbank/operators/CommunityConcept.py
@@ -469,6 +469,9 @@ class CommunityConcept(Operator):
                     data['cc'], conn, what_to_deactivate = what_to_deactivate)
                 dataset['commconcept'] = [item['vb_cc_code']
                                        for item in cc_actions['resources']['cc']]
+                dataset['commname'] = [item['vb_cn_code']
+                                            for item in cc_actions['resources']['cn']
+                                            if item['action'] == 'INSERT']
                 to_return = combine_json_return(to_return, cc_actions)
 
                 # Prep & insert any new community names
@@ -494,6 +497,9 @@ class CommunityConcept(Operator):
                             {"user_py_code": "user_usage_py_code",
                              "vb_py_code": "vb_usage_py_code"})
                     cn_actions = self.upload_community_names(data['cn'], conn)
+                    dataset['commname'] += [item['vb_cn_code']
+                                            for item in cn_actions['resources']['cun']
+                                            if item['action'] == 'INSERT']
                     to_return = combine_json_return(to_return, cn_actions)
                 else:
                     cn_actions = None

--- a/src/vegbank/operators/PlantConcept.py
+++ b/src/vegbank/operators/PlantConcept.py
@@ -470,6 +470,9 @@ class PlantConcept(Operator):
                     data['pc'], conn, what_to_deactivate = what_to_deactivate)
                 dataset['plantconcept'] = [item['vb_pc_code']
                                             for item in pc_actions['resources']['pc']]
+                dataset['plantname'] = [item['vb_pn_code']
+                                            for item in pc_actions['resources']['pn']
+                                            if item['action'] == 'INSERT']
                 to_return = combine_json_return(to_return, pc_actions)
 
                 # Prep & insert any new plant names
@@ -496,8 +499,9 @@ class PlantConcept(Operator):
                             {"user_py_code": "user_usage_py_code",
                              "vb_py_code": "vb_usage_py_code"})
                     pn_actions = self.upload_plant_names(data['pn'], conn)
-                    dataset['plantname'] = [item['vb_pn_code']
-                                            for item in pn_actions['resources']['pun']]
+                    dataset['plantname'] += [item['vb_pn_code']
+                                            for item in pn_actions['resources']['pun']
+                                            if item['action'] == 'INSERT']
                     to_return = combine_json_return(to_return, pn_actions)
                 else:
                     pn_actions = None


### PR DESCRIPTION
### What
This PR adds a check to the dataset item creation steps for plant and community concepts that only adds names with a merge action status of 'INSERT' to the dataset. Previously, all names were added whether they were matched or not, which ended up with duplicate dataset item records that could lead to misattributed data. 

### Why
The automatically created upload datasets are designed to track who uploaded what data. Double adding names muddies that tracking, and this fixes that problem in case a set of name records had to be removed or changed for any reason. 

### How
I've added a check on the 'action' field of newly created name records when adding things to the dataset dictionary prior to calling the upload dataset method. It now only takes names with a status of 'INSERT'. 

This also fixes a bug where only name records created from the X_names file would be created when name records are also created from the X_concepts files. Now we add to the dataset dictionary from both of those files. 