### PR TITLE
Feature 370: Enforce WSGI Header Size Limits in Gunicorn

### DIFF
--- a/helm/config/gunicorn.conf.py
+++ b/helm/config/gunicorn.conf.py
@@ -6,6 +6,8 @@ timeout = os.getenv('GUNICORN_TIMEOUT', default={{ .Values.gunicorn.timeout }})
 
 bind = os.getenv('GUNICORN_PORT', default="0.0.0.0:{{ .Values.service.port }}")
 
+limit_request_field_size = os.getenv('GUNICORN_LIMIT_REQUEST_FIELD_SIZE', default={{ .Values.gunicorn.limitRequestFieldSize }})
+
 accesslog = os.getenv('GUNICORN_ACCESSLOG', default='-') # Access Log to stdout
 errorlog = os.getenv('GUNICORN_ERRORLOG', default='-') # Error Log to stdout
 {{- $validLogLevels := tuple "debug" "info" "warning" "error" "critical" }}

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -255,6 +255,9 @@ gunicorn:
   ##
   logLevel: "info"
 
+  ## @param gunicorn.limitRequestFieldSize The maximum size of HTTP request header fields in bytes. Default is 8KB, but this is upped to 16kb to match the limit set at the auth stage.
+  limitRequestFieldSize: 16384   
+
 ## @section Ingress
 ## Configuration for the ingress, including certifications and host name. There is no configured
 ## service section here because the ingress automatically pulls the default named service for the


### PR DESCRIPTION
### What
This PR sets the limit_request_field_size parameter in gunicorn to ~16KB, which matches the limit set in the auth.py file. This is about double the default value provided by gunicorn. 

### Why
It was decided that these values should match rather than gunicorn having a smaller limit. 

### How
I've added it to the gunicorn config file and to the values file in the gunicorn section. Like our other params, the values file is a default setting, and there is a provided option to instead use environment variables rather than a helm template down the road if necessary. 

see  #370 
