### PR TITLE
trimming debug mode setting on the app run statements

### DIFF
--- a/src/vegbank/app.py
+++ b/src/vegbank/app.py
@@ -12,4 +12,4 @@ def create_app():
 
 if __name__ == '__main__':
     app = create_app()
-    app.run(port=8000, debug=True)
+    app.run(port=8000)

--- a/src/vegbank/gunicorn_main.py
+++ b/src/vegbank/gunicorn_main.py
@@ -1,6 +1,6 @@
 from vegbank.app import create_app
 
 if __name__ == '__main__':
-   create_app().run(port=8000, debug=True)
+   create_app().run(port=8000)
 else:
    app = create_app() 


### PR DESCRIPTION
### What
This PR removes the debug=true lines from the two places we run the vegbank API app itself. This is to avoid security concerns on deployed instances. gunicorn_main is the call the deployed server makes and therefore shouldn't be run in debug by default, and even though app.py is only run as main during local development, we're changing it to default off, and developers can set it locally if necessary. 