### PR TITLE
Patch 2.1.1 configurable auth scopes

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 
 ## Citation and Overview
 
-> *Jim Regetz, Robert Shelton, Darian Gill, Matthew B. Jones, Dou Mok, Matthew Brooke, Rushiraj Nenuji, Jeanette Clark, Maggie Klope, Michael T. Lee, Robert K. Peet*. 2026. **VegBank: the open-access vegetation plot database and API of the Ecological Society of America’s Panel on Vegetation Classification**. Version 2.1.0. VegBank. [doi:10.82902/J1WC7G](https://doi.org/10.82902/J1WC7G).
+> *Jim Regetz, Robert Shelton, Darian Gill, Matthew B. Jones, Dou Mok, Matthew Brooke, Rushiraj Nenuji, Jeanette Clark, Maggie Klope, Michael T. Lee, Robert K. Peet*. 2026. **VegBank: the open-access vegetation plot database and API of the Ecological Society of America’s Panel on Vegetation Classification**. Version 2.1.1. VegBank. [doi:10.82902/J1WC7G](https://doi.org/10.82902/J1WC7G).
 
 The [VegBank](http://vegbank.org) data system provides a community managed data portal for
 vegetation plot data, with special emphasis on supporting the U.S. National Vegetation

--- a/api/openapi.yml
+++ b/api/openapi.yml
@@ -1,7 +1,7 @@
 openapi: '3.0.3'
 info:
   title: VegBankAPI
-  version: '2.1.0'
+  version: '2.1.1'
   license:
     name: Apache 2.0
     url: https://www.apache.org/licenses/LICENSE-2.0.html

--- a/helm/Chart.yaml
+++ b/helm/Chart.yaml
@@ -22,10 +22,10 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: "1.1.0"
+version: "1.1.1"
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "2.1.0"
+appVersion: "2.1.1"

--- a/helm/README.md
+++ b/helm/README.md
@@ -178,14 +178,14 @@ If you are testing new schema updates, add them to `helm/db/migrations` with the
 
 ### API Access - Authentication and Authorization
 
-| Name                        | Description                                                         | Value                   |
-| --------------------------- | ------------------------------------------------------------------- | ----------------------- |
-| `auth.accessMode`           | Controls authentication & upload behavior (RW or RO) for API access | `read_only`             |
-| `auth.oidcSecretName`       | Name of the Kubernetes secret containing client_secrets.json        | `vegbank-oidc-config`   |
-| `auth.oidcDefaultScopes`    | Space-separated standard OIDC scopes requested during login         | `openid email profile`  |
-| `auth.roleName.admin`       | Scope name for the admin role                                       | `vegbank:admin`         |
-| `auth.roleName.contributor` | Scope name for the contributor role                                 | `vegbank:contributor`   |
-| `auth.roleName.user`        | Scope name for the user role                                        | `vegbank:user`          |
+| Name                        | Description                                                         | Value                  |
+| --------------------------- | ------------------------------------------------------------------- | ---------------------- |
+| `auth.accessMode`           | Controls authentication & upload behavior (RW or RO) for API access | `read_only`            |
+| `auth.oidcSecretName`       | Name of the Kubernetes secret containing client_secrets.json        | `vegbank-oidc-config`  |
+| `auth.oidcDefaultScopes`    | Space-separated standard OIDC scopes requested during login.        | `openid email profile` |
+| `auth.roleName.admin`       | Scope name for the admin role                                       | `vegbank:admin`        |
+| `auth.roleName.contributor` | Scope name for the contributor role                                 | `vegbank:contributor`  |
+| `auth.roleName.user`        | Scope name for the user role                                        | `vegbank:user`         |
 
 ### Database
 
@@ -260,11 +260,12 @@ If you are testing new schema updates, add them to `helm/db/migrations` with the
 
 ### Gunicorn Server
 
-| Name                | Description                                                             | Value  |
-| ------------------- | ----------------------------------------------------------------------- | ------ |
-| `gunicorn.workers`  | Number of worker processes for handling requests.                       | `5`    |
-| `gunicorn.timeout`  | Workers silent for more than this many seconds are killed and restarted | `2400` |
-| `gunicorn.logLevel` | Granularity of gunicorn logs (debug|info|warning|error|critical)        | `info` |
+| Name                             | Description                                                                                                                                  | Value   |
+| -------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------- | ------- |
+| `gunicorn.workers`               | Number of worker processes for handling requests.                                                                                            | `5`     |
+| `gunicorn.timeout`               | Workers silent for more than this many seconds are killed and restarted                                                                      | `2400`  |
+| `gunicorn.logLevel`              | Granularity of gunicorn logs (debug|info|warning|error|critical)                                                                             | `info`  |
+| `gunicorn.limitRequestFieldSize` | The maximum size of HTTP request header fields in bytes. Default is 8KB, but this is upped to 16kb to match the limit set at the auth stage. | `16384` |
 
 ### Ingress
 

--- a/helm/README.md
+++ b/helm/README.md
@@ -178,13 +178,14 @@ If you are testing new schema updates, add them to `helm/db/migrations` with the
 
 ### API Access - Authentication and Authorization
 
-| Name                        | Description                                                         | Value                 |
-| --------------------------- | ------------------------------------------------------------------- | --------------------- |
-| `auth.accessMode`           | Controls authentication & upload behavior (RW or RO) for API access | `read_only`           |
-| `auth.oidcSecretName`       | Name of the Kubernetes secret containing client_secrets.json        | `vegbank-oidc-config` |
-| `auth.roleName.admin`       | Scope name for the admin role                                       | `vegbank:admin`       |
-| `auth.roleName.contributor` | Scope name for the contributor role                                 | `vegbank:contributor` |
-| `auth.roleName.user`        | Scope name for the user role                                        | `vegbank:user`        |
+| Name                        | Description                                                         | Value                   |
+| --------------------------- | ------------------------------------------------------------------- | ----------------------- |
+| `auth.accessMode`           | Controls authentication & upload behavior (RW or RO) for API access | `read_only`             |
+| `auth.oidcSecretName`       | Name of the Kubernetes secret containing client_secrets.json        | `vegbank-oidc-config`   |
+| `auth.oidcDefaultScopes`    | Space-separated standard OIDC scopes requested during login         | `openid email profile`  |
+| `auth.roleName.admin`       | Scope name for the admin role                                       | `vegbank:admin`         |
+| `auth.roleName.contributor` | Scope name for the contributor role                                 | `vegbank:contributor`   |
+| `auth.roleName.user`        | Scope name for the user role                                        | `vegbank:user`          |
 
 ### Database
 

--- a/helm/admin/client-secrets.json
+++ b/helm/admin/client-secrets.json
@@ -4,6 +4,5 @@
     "client_secret": "<your-client-secret-here>",
     "redirect_uris": [
         "https://test.dataone.org/authorize"
-    ],
-    "scope_request": "openid email"
+    ]
 }

--- a/helm/docs/api-authorization.md
+++ b/helm/docs/api-authorization.md
@@ -191,7 +191,7 @@ The `client_secrets.json` file is required for communication with the OIDC provi
 }
 ```
 
-The `server_metadata_url` tells the system where to find OIDC keys, token endpoints, and other config. Scopes are **not** read from this file — they are controlled exclusively via environment variables (see above).
+The `server_metadata_url` tells the system where to find OIDC keys, token endpoints, and other config.
 
 
 ### Protecting Endpoints

--- a/helm/docs/api-authorization.md
+++ b/helm/docs/api-authorization.md
@@ -172,22 +172,26 @@ FLASK_SECRET_KEY=your-secret-key
 
 # OIDC/Keycloak configuration
 OIDC_CLIENT_SECRETS_FILE=/path/to/client_secrets.json
+
+# Standard OIDC scopes to request during login (default: "openid email profile")
+# VegBank role scopes (VB_SCOPE_ADMIN/CONTRIBUTOR/USER) are always appended automatically.
+# Set via the auth.oidcDefaultScopes Helm value.
+VB_OIDC_DEFAULT_SCOPES=openid email profile
 ```
 
 #### Client Secrets File format
 
-The `client_secrets.json` file is required for communication with the OIDC provider. 
+The `client_secrets.json` file is required for communication with the OIDC provider.
 
 ```json
 {
   "client_id": "vegbank-api-client",
   "client_secret": "your-client-secret-from-keycloak",
-  "server_metadata_url": "https://auth.vegbank.org/auth/realms/vegbank/.well-known/openid-configuration",
-  "scope_request": "openid email profile vegbank:admin vegbank:contributor vegbank:user"
+  "server_metadata_url": "https://auth.vegbank.org/auth/realms/vegbank/.well-known/openid-configuration"
 }
 ```
 
-The `server_metadata_url` tells the system where to find OIDC keys, token endpoints, and other config.
+The `server_metadata_url` tells the system where to find OIDC keys, token endpoints, and other config. Scopes are **not** read from this file — they are controlled exclusively via environment variables (see above).
 
 
 ### Protecting Endpoints

--- a/helm/examples/values-overrides-dev-vb-dev.yaml
+++ b/helm/examples/values-overrides-dev-vb-dev.yaml
@@ -8,6 +8,14 @@
 ##
 auth:
   accessMode: "authenticated"
+  ## @param auth.roleName.admin Scope name for the admin role
+  ## @param auth.roleName.contributor Scope name for the contributor role
+  ## @param auth.roleName.user Scope name for the user role
+  ##
+  roleName:
+    admin: "vegbank-dev:admin"
+    contributor: "vegbank-dev:contributor"
+    user: "vegbank-dev:user"
 
 replicaCount: 1
 

--- a/helm/examples/values-overrides-dev-vb.yaml
+++ b/helm/examples/values-overrides-dev-vb.yaml
@@ -8,6 +8,14 @@
 ##
 auth:
   accessMode: "authenticated"
+  ## @param auth.roleName.admin Scope name for the admin role
+  ## @param auth.roleName.contributor Scope name for the contributor role
+  ## @param auth.roleName.user Scope name for the user role
+  ##
+  roleName:
+    admin: "vegbank-dev:admin"
+    contributor: "vegbank-dev:contributor"
+    user: "vegbank-dev:user"
 
 replicaCount: 2
 

--- a/helm/templates/deployment.yaml
+++ b/helm/templates/deployment.yaml
@@ -171,6 +171,8 @@ spec:
           env:
             - name: VB_ACCESS_MODE
               value: {{ .Values.auth.accessMode | quote }}
+            - name: VB_OIDC_DEFAULT_SCOPES
+              value: {{ .Values.auth.oidcDefaultScopes | quote }}
             - name: VB_SCOPE_ADMIN
               value: {{ .Values.auth.roleName.admin | quote }}
             - name: VB_SCOPE_CONTRIBUTOR

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -43,6 +43,12 @@ auth:
   ##
   oidcSecretName: vegbank-oidc-config
 
+  ## @param auth.oidcDefaultScopes Space-separated standard OIDC scopes requested during login.
+  ## Override this if your OIDC provider requires a different set of base scopes.
+  ## VegBank role scopes (admin/contributor/user below) are always appended automatically.
+  ##
+  oidcDefaultScopes: "openid email profile"
+
   ## @param auth.roleName.admin Scope name for the admin role
   ## @param auth.roleName.contributor Scope name for the contributor role
   ## @param auth.roleName.user Scope name for the user role

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "vegbank"
-version = "2.1.0"
+version = "2.1.1"
 description = "VegBank database and data access service"
 authors = [
     { name = "Robert Shelton", email = "shelton@nceas.ucsb.edu" },

--- a/src/vegbank/auth.py
+++ b/src/vegbank/auth.py
@@ -120,12 +120,20 @@ def init_oauth(app) -> bool:
         app.wsgi_app = ProxyFix(app.wsgi_app, x_proto=1, x_host=1)
 
     oauth.init_app(app)
+
+    # Base OIDC scopes come from the secrets file; VegBank scopes come from
+    # env vars (set by Helm values). Merge and deduplicate to build the final
+    # scope string.
+    base_scopes = secrets.get("scope_request", "").split()
+    vb_scopes = [SCOPE_ADMIN, SCOPE_CONTRIBUTOR, SCOPE_USER]
+    scope_request = " ".join(dict.fromkeys(base_scopes + vb_scopes))
+
     oauth.register(
         name="vegbank_oidc",
         client_id=secrets.get("client_id"),
         client_secret=secrets.get("client_secret"),
         server_metadata_url=secrets.get("server_metadata_url"),
-        client_kwargs={"scope": secrets.get("scope_request", "openid email profile vegbank:admin vegbank:contributor vegbank:user")},
+        client_kwargs={"scope": scope_request},
     )
 
     logger.info("OAuth client initialised.")

--- a/src/vegbank/auth.py
+++ b/src/vegbank/auth.py
@@ -53,6 +53,9 @@ MAX_TOKEN_LEN = 16_384  # Token length limit in characters (~16 KB) to prevent D
 class MissingParameterError(Exception):
     """Raised when a required request parameter is missing."""
 
+# Standard OIDC scopes — overridable via environment variable
+DEFAULT_SCOPES = os.getenv("VB_OIDC_DEFAULT_SCOPES", "openid email profile")
+
 # VegBank-specific scopes — configurable via environment variables set by Helm
 SCOPE_ADMIN = os.getenv("VB_SCOPE_ADMIN", "vegbank:admin")
 SCOPE_CONTRIBUTOR = os.getenv("VB_SCOPE_CONTRIBUTOR", "vegbank:contributor")
@@ -121,10 +124,9 @@ def init_oauth(app) -> bool:
 
     oauth.init_app(app)
 
-    # Base OIDC scopes come from the secrets file; VegBank scopes come from
-    # env vars (set by Helm values). Merge and deduplicate to build the final
-    # scope string.
-    base_scopes = secrets.get("scope_request", "").split()
+    # Build scope string from: standard OIDC defaults (VB_OIDC_DEFAULT_SCOPES) +
+    # VegBank-specific scopes (set by Helm values). Deduplicate while preserving order.
+    base_scopes = DEFAULT_SCOPES.split()
     vb_scopes = [SCOPE_ADMIN, SCOPE_CONTRIBUTOR, SCOPE_USER]
     scope_request = " ".join(dict.fromkeys(base_scopes + vb_scopes))
 

--- a/uv.lock
+++ b/uv.lock
@@ -854,7 +854,7 @@ wheels = [
 
 [[package]]
 name = "vegbank"
-version = "2.1.0"
+version = "2.1.1"
 source = { editable = "." }
 dependencies = [
     { name = "adbc-driver-postgresql" },


### PR DESCRIPTION
~~Updates `auth.py` to get scopes from the KeyCloak secrets file, and appends configurable scopes (as set in `values.yaml`) to the OAuth request during initialization.~~


Updates `auth.py` to use default OIDC scopes (sets `VB_OIDC_DEFAULT_SCOPES` via env var) and VB specific scopes both as set in the `values.yaml` file. Scopes list from Keycloak secrets file are not required. (ignored)