### PR TITLE
Bug 495: Adding ON COMMIT DROP to all temp table inserts

### DIFF
--- a/src/vegbank/queries/community_classification/comm_class/create_comm_class_temp_table.sql
+++ b/src/vegbank/queries/community_classification/comm_class/create_comm_class_temp_table.sql
@@ -11,4 +11,4 @@ CREATE TEMPORARY TABLE comm_class_temp(
     user_rf_code TEXT,
     classnotes TEXT,
     vb_ob_code TEXT NOT NULL
-);
+) ON COMMIT DROP;

--- a/src/vegbank/queries/community_classification/comm_interp/create_comm_interp_temp_table.sql
+++ b/src/vegbank/queries/community_classification/comm_interp/create_comm_interp_temp_table.sql
@@ -10,4 +10,4 @@ CREATE TEMPORARY TABLE comm_interp_temp(
     nomenclaturaltype BOOLEAN,
     user_ci_code TEXT NOT NULL,
     vb_cl_code TEXT NOT NULL
-);
+) ON COMMIT DROP;

--- a/src/vegbank/queries/community_concept/comm_concept/create_comm_concept_temp_table.sql
+++ b/src/vegbank/queries/community_concept/comm_concept/create_comm_concept_temp_table.sql
@@ -5,4 +5,4 @@ CREATE TEMPORARY TABLE comm_concept_temp(
     commname TEXT,
     commdescription TEXT,
     vb_cn_code TEXT NOT NULL
-);
+) ON COMMIT DROP;

--- a/src/vegbank/queries/community_concept/comm_name/create_comm_name_temp_table.sql
+++ b/src/vegbank/queries/community_concept/comm_name/create_comm_name_temp_table.sql
@@ -1,4 +1,4 @@
 CREATE TEMPORARY TABLE comm_name_temp(
     commname TEXT,
     user_cn_code TEXT
-);
+) ON COMMIT DROP;

--- a/src/vegbank/queries/community_concept/comm_status/create_comm_status_temp_table.sql
+++ b/src/vegbank/queries/community_concept/comm_status/create_comm_status_temp_table.sql
@@ -13,4 +13,4 @@ CREATE TEMPORARY TABLE comm_status_temp(
     user_py_code TEXT,
     user_cs_code TEXT NOT NULL,
     vb_cc_code TEXT NOT NULL
-);
+) ON COMMIT DROP;

--- a/src/vegbank/queries/community_correlation/comm_correlation/create_comm_correlation_temp_table.sql
+++ b/src/vegbank/queries/community_correlation/comm_correlation/create_comm_correlation_temp_table.sql
@@ -9,4 +9,4 @@ CREATE TEMPORARY TABLE comm_correlation_temp(
     -- api-augmented fields:
     vb_cc_code TEXT NOT NULL,
     user_cx_code TEXT NOT NULL
-);
+) ON COMMIT DROP;

--- a/src/vegbank/queries/community_name/comm_name/create_comm_name_temp_table.sql
+++ b/src/vegbank/queries/community_name/comm_name/create_comm_name_temp_table.sql
@@ -1,4 +1,4 @@
 CREATE TEMPORARY TABLE comm_usage_name_temp(
     commname TEXT,
     user_cn_code TEXT
-);
+) ON COMMIT DROP;

--- a/src/vegbank/queries/community_name/comm_usage/create_comm_usage_temp_table.sql
+++ b/src/vegbank/queries/community_name/comm_usage/create_comm_usage_temp_table.sql
@@ -13,4 +13,4 @@ CREATE TEMPORARY TABLE comm_usage_temp(
     vb_cs_code TEXT NOT NULL,
     vb_cn_code TEXT NOT NULL,
     user_cu_code TEXT NOT NULL
-);
+) ON COMMIT DROP;

--- a/src/vegbank/queries/cover_method/cover_index/create_cover_index_temp_table.sql
+++ b/src/vegbank/queries/cover_method/cover_index/create_cover_index_temp_table.sql
@@ -6,4 +6,4 @@ CREATE TEMPORARY TABLE cover_index_temp (
     lowerlimit double precision,
     coverpercent double precision NOT NULL,
     indexdescription text
-);
+) ON COMMIT DROP;

--- a/src/vegbank/queries/cover_method/cover_method/create_cover_method_temp_table.sql
+++ b/src/vegbank/queries/cover_method/cover_method/create_cover_method_temp_table.sql
@@ -4,4 +4,4 @@ CREATE TEMPORARY TABLE cover_method_temp(
     vb_rf_code TEXT,
     covertype character varying(30) NOT NULL,
     coverestimationmethod character varying(80)
-);
+) ON COMMIT DROP;

--- a/src/vegbank/queries/disturbance/disturbance_obs/create_disturbance_obs_temp_table.sql
+++ b/src/vegbank/queries/disturbance/disturbance_obs/create_disturbance_obs_temp_table.sql
@@ -9,4 +9,4 @@ CREATE TEMPORARY TABLE disturbance_obs_temp(
     disturbancecomment TEXT,
     -- api-augmented fields:
     vb_ob_code TEXT NOT NULL
-);
+) ON COMMIT DROP;

--- a/src/vegbank/queries/party/class_contributor/create_class_contributor_temp_table.sql
+++ b/src/vegbank/queries/party/class_contributor/create_class_contributor_temp_table.sql
@@ -7,4 +7,4 @@ CREATE TEMPORARY TABLE class_contributor_temp
         record_identifier TEXT NOT NULL,
         vb_record_identifier TEXT, 
         vb_py_code TEXT
-    );
+    ) ON COMMIT DROP;

--- a/src/vegbank/queries/party/observation_contributor/create_observation_contributor_temp_table.sql
+++ b/src/vegbank/queries/party/observation_contributor/create_observation_contributor_temp_table.sql
@@ -7,4 +7,4 @@ CREATE TEMPORARY TABLE observation_contributor_temp
         record_identifier TEXT NOT NULL,
         vb_record_identifier TEXT, 
         vb_py_code TEXT
-    );
+    ) ON COMMIT DROP;

--- a/src/vegbank/queries/party/party/create_party_temp_table.sql
+++ b/src/vegbank/queries/party/party/create_party_temp_table.sql
@@ -7,4 +7,4 @@ CREATE TEMPORARY TABLE party_temp(
     email character varying(120),
     orcid TEXT,
     ror TEXT
-);
+) ON COMMIT DROP;

--- a/src/vegbank/queries/party/project_contributor/create_project_contributor_temp_table.sql
+++ b/src/vegbank/queries/party/project_contributor/create_project_contributor_temp_table.sql
@@ -7,4 +7,4 @@ CREATE TEMPORARY TABLE project_contributor_temp
         record_identifier TEXT NOT NULL,
         vb_record_identifier TEXT, 
         vb_py_code TEXT
-    );
+    ) ON COMMIT DROP;

--- a/src/vegbank/queries/plant_concept/plant_concept/create_plant_concept_temp_table.sql
+++ b/src/vegbank/queries/plant_concept/plant_concept/create_plant_concept_temp_table.sql
@@ -5,4 +5,4 @@ CREATE TEMPORARY TABLE plant_concept_temp(
     plantname TEXT,
     plantdescription TEXT,
     vb_pn_code TEXT NOT NULL
-);
+) ON COMMIT DROP;

--- a/src/vegbank/queries/plant_concept/plant_name/create_plant_name_temp_table.sql
+++ b/src/vegbank/queries/plant_concept/plant_name/create_plant_name_temp_table.sql
@@ -1,4 +1,4 @@
 CREATE TEMPORARY TABLE plant_name_temp(
     plantname TEXT,
     user_pn_code TEXT
-);
+) ON COMMIT DROP;

--- a/src/vegbank/queries/plant_concept/plant_status/create_plant_status_temp_table.sql
+++ b/src/vegbank/queries/plant_concept/plant_status/create_plant_status_temp_table.sql
@@ -13,4 +13,4 @@ CREATE TEMPORARY TABLE plant_status_temp(
     user_py_code TEXT,
     user_ps_code TEXT NOT NULL,
     vb_pc_code TEXT NOT NULL
-);
+) ON COMMIT DROP;

--- a/src/vegbank/queries/plant_correlation/plant_correlation/create_plant_correlation_temp_table.sql
+++ b/src/vegbank/queries/plant_correlation/plant_correlation/create_plant_correlation_temp_table.sql
@@ -9,4 +9,4 @@ CREATE TEMPORARY TABLE plant_correlation_temp(
     -- api-augmented fields:
     vb_pc_code TEXT NOT NULL,
     user_px_code TEXT NOT NULL
-);
+) ON COMMIT DROP;

--- a/src/vegbank/queries/plant_name/plant_name/create_plant_name_temp_table.sql
+++ b/src/vegbank/queries/plant_name/plant_name/create_plant_name_temp_table.sql
@@ -1,4 +1,4 @@
 CREATE TEMPORARY TABLE plant_usage_name_temp(
     plantname TEXT,
     user_pn_code TEXT
-);
+) ON COMMIT DROP;

--- a/src/vegbank/queries/plant_name/plant_usage/create_plant_usage_temp_table.sql
+++ b/src/vegbank/queries/plant_name/plant_usage/create_plant_usage_temp_table.sql
@@ -13,4 +13,4 @@ CREATE TEMPORARY TABLE plant_usage_temp(
     vb_ps_code TEXT NOT NULL,
     vb_pn_code TEXT NOT NULL,
     user_pu_code TEXT NOT NULL
-);
+) ON COMMIT DROP;

--- a/src/vegbank/queries/plot_observation/observation/create_observation_temp_table.sql
+++ b/src/vegbank/queries/plot_observation/observation/create_observation_temp_table.sql
@@ -67,4 +67,4 @@ CREATE TEMP TABLE observation_temp(
     growthform3cover double precision,
     totalcover double precision,
     hasobservationsynonym boolean 
-)
+) ON COMMIT DROP;

--- a/src/vegbank/queries/plot_observation/plot/create_plot_temp_table.sql
+++ b/src/vegbank/queries/plot_observation/plot/create_plot_temp_table.sql
@@ -43,4 +43,4 @@ CREATE TEMP TABLE plot_temp (
     submitter_surname character varying(100),
     submitter_givenname character varying(100),
     submitter_email character varying(100)
-);
+) ON COMMIT DROP;

--- a/src/vegbank/queries/project/project/create_project_temp_table.sql
+++ b/src/vegbank/queries/project/project/create_project_temp_table.sql
@@ -4,4 +4,4 @@ CREATE TEMP TABLE project_temp (
     projectdescription text,
     startdate timestamp with time zone,
     stopdate timestamp with time zone
-);
+) ON COMMIT DROP;

--- a/src/vegbank/queries/reference/reference/create_reference_temp_table.sql
+++ b/src/vegbank/queries/reference/reference/create_reference_temp_table.sql
@@ -4,4 +4,4 @@ CREATE TEMPORARY TABLE reference_temp(
     shortname character varying(250),
     fulltext TEXT,
     url TEXT
-);
+) ON COMMIT DROP;

--- a/src/vegbank/queries/soil/soil_obs/create_soil_obs_temp_table.sql
+++ b/src/vegbank/queries/soil/soil_obs/create_soil_obs_temp_table.sql
@@ -18,4 +18,4 @@ CREATE TEMPORARY TABLE soil_obs_temp(
     soildescription TEXT,
     -- api-augmented fields:
     vb_ob_code TEXT NOT NULL
-);
+) ON COMMIT DROP;

--- a/src/vegbank/queries/stratum_method/stratum_method/create_stratum_method_temp_table.sql
+++ b/src/vegbank/queries/stratum_method/stratum_method/create_stratum_method_temp_table.sql
@@ -5,4 +5,4 @@ CREATE TEMPORARY TABLE stratum_method_temp(
     stratummethodname TEXT NOT NULL,
     stratummethoddescription TEXT,
     stratumassignment TEXT
-);
+) ON COMMIT DROP;

--- a/src/vegbank/queries/stratum_method/stratum_type/create_stratum_type_temp_table.sql
+++ b/src/vegbank/queries/stratum_method/stratum_type/create_stratum_type_temp_table.sql
@@ -4,4 +4,4 @@ CREATE TEMPORARY TABLE stratum_type_temp (
     stratumname TEXT,
     stratumdescription text,
     vb_sm_code TEXT NOT NULL
-);
+) ON COMMIT DROP;

--- a/src/vegbank/queries/taxon_observation/stem_count/create_stem_count_temp_table.sql
+++ b/src/vegbank/queries/taxon_observation/stem_count/create_stem_count_temp_table.sql
@@ -8,4 +8,4 @@ CREATE TEMPORARY TABLE stem_count_temp(
     stemheight double precision,
     stemheightaccuracy double precision,
     stemtaxonarea double precision
-);
+) ON COMMIT DROP;

--- a/src/vegbank/queries/taxon_observation/stem_location/create_stem_location_temp_table.sql
+++ b/src/vegbank/queries/taxon_observation/stem_location/create_stem_location_temp_table.sql
@@ -5,4 +5,4 @@ CREATE TEMPORARY TABLE stem_location_temp(
     stemxposition double precision,
     stemyposition double precision,
     stemhealth character varying(50)
-);
+) ON COMMIT DROP;

--- a/src/vegbank/queries/taxon_observation/stratum/create_stratum_temp_table.sql
+++ b/src/vegbank/queries/taxon_observation/stratum/create_stratum_temp_table.sql
@@ -6,4 +6,4 @@ CREATE TEMPORARY TABLE stratum_temp(
     stratumheight double precision,
     stratumbase double precision,
     stratumcover double precision
-);
+) ON COMMIT DROP;

--- a/src/vegbank/queries/taxon_observation/taxon_importance/create_taxon_importance_temp_table.sql
+++ b/src/vegbank/queries/taxon_observation/taxon_importance/create_taxon_importance_temp_table.sql
@@ -8,4 +8,4 @@ CREATE TEMPORARY TABLE taxon_importance_temp(
     basalarea double precision,
     biomass double precision,
     inferencearea double precision
-);
+) ON COMMIT DROP;

--- a/src/vegbank/queries/taxon_observation/taxon_interpretation/create_taxon_interpretation_temp_table.sql
+++ b/src/vegbank/queries/taxon_observation/taxon_interpretation/create_taxon_interpretation_temp_table.sql
@@ -23,4 +23,4 @@ CREATE TEMPORARY TABLE taxon_interpretation_temp(
     museumaccessionnumber character varying(100),
     grouptype character varying(20),
     notes text
-);
+) ON COMMIT DROP;

--- a/src/vegbank/queries/taxon_observation/taxon_observation/create_taxon_observation_temp_table.sql
+++ b/src/vegbank/queries/taxon_observation/taxon_observation/create_taxon_observation_temp_table.sql
@@ -5,4 +5,4 @@ CREATE TEMPORARY TABLE taxon_observation_temp(
     authorplantname character varying(255) NOT NULL,
     vb_rf_code TEXT,
     taxoninferencearea double precision
-);
+) ON COMMIT DROP;

--- a/src/vegbank/queries/user_dataset/user_dataset_item/create_user_dataset_item_temp_table.sql
+++ b/src/vegbank/queries/user_dataset/user_dataset_item/create_user_dataset_item_temp_table.sql
@@ -5,4 +5,4 @@ CREATE TEMPORARY TABLE user_dataset_item_temp (
     itemdatabase TEXT NOT NULL, 
     itemtable TEXT NOT NULL,
     itemrecord INTEGER NOT NULL
-);
+) ON COMMIT DROP;


### PR DESCRIPTION
### What
This PR fixes a bug when multiple upload methods are called in succession on an environment with pgBouncer installed. The temp tables were not correctly dropped at the end of transactions when multiple uploads happened on the same pool connections. 

### How
I've added a DROP ON COMMIT statement to the end of all the temp table creates. This ensures they will be dropped at the end of the transaction. 

### Why
This bug was preventing multiple inserts in quick succession. 