### PR TITLE
Bug 490: Adding error handle for unicode decode error when creating table inputs

### DIFF
--- a/src/vegbank/operators/operator_parent_class.py
+++ b/src/vegbank/operators/operator_parent_class.py
@@ -704,7 +704,13 @@ class Operator:
             duplicated_codes = table_df.loc[duplicate_user_codes, join_field_name].tolist()
             raise ValueError(f"The following user codes are duplicated in the upload data for table {insert_table_name}: {duplicated_codes}")
 
-        table_inputs = list(table_df.itertuples(index=False, name=None))
+        try:
+            table_inputs = list(table_df.itertuples(index=False, name=None))
+        except UnicodeDecodeError as e:
+            raise ValueError(
+                f"Uninterpretable text encountered in {insert_table_name} - "
+                "ensure your file is saved with UTF-8 encoding before uploading."
+            )
         with conn.cursor() as cur:
             sql_file_temp_table = os.path.join(
                 f"{insert_table_name}/create_{insert_table_name}_temp_table.sql"


### PR DESCRIPTION
### What
This PR adds a more descriptive error message when a particular UTF-8 related error occurs in the upload_to_table method. 

### How
Jim has provided a particular try/catch for this one type of error and some associated language to help users troubleshoot where their non UTF-8 text is. 

### Why
Previously, this error didn't display any helpful information regarding where/why the error was occurring. 