### PR TITLE
Bug 488: Automatically created upload datasets do not attach user data 

### DIFF
--- a/src/vegbank/operators/CommunityClassification.py
+++ b/src/vegbank/operators/CommunityClassification.py
@@ -346,7 +346,7 @@ class CommunityClassification(Operator):
         }
         return to_return
 
-    def upload_all(self, request):
+    def upload_all(self, request, claims=None):
         """
         Orchestrate the insertion of client-provided Community Classification
         data into VegBank, starting with the Flask request containing the
@@ -506,7 +506,7 @@ class CommunityClassification(Operator):
                 }
                 start = time.time()
                 ds = UserDataset(self.params).upload_user_dataset(
-                    dataset_input, conn)
+                    dataset_input, conn, claims=claims)
                 print(ds)
                 end = time.time()
                 print(f"Time to upload dataset: {end - start} seconds")

--- a/src/vegbank/operators/CommunityConcept.py
+++ b/src/vegbank/operators/CommunityConcept.py
@@ -333,7 +333,7 @@ class CommunityConcept(Operator):
 
         return params
 
-    def upload_all(self, request):
+    def upload_all(self, request, claims=None):
         """
         Orchestrate the insertion of client-provided Community Concept data into
         VegBank, starting with the Flask request containing the uploaded data
@@ -544,7 +544,7 @@ class CommunityConcept(Operator):
                 }
                 start = time.time()
                 ds = UserDataset(self.params).upload_user_dataset(
-                    dataset_input, conn)
+                    dataset_input, conn, claims=claims)
                 print(ds)
                 end = time.time()
                 print(f"Time to upload dataset: {end - start} seconds")

--- a/src/vegbank/operators/CoverMethod.py
+++ b/src/vegbank/operators/CoverMethod.py
@@ -169,7 +169,7 @@ class CoverMethod(Operator):
 
         return to_return
 
-    def upload_all(self, request):
+    def upload_all(self, request, claims=None):
         '''
         Handles the upload of cover method data, including associated reference data if provided, and cover index data. Validates the uploaded data, uploads it to the database, and creates a new user dataset with the uploaded data. Expects a multipart/form-data request with parquet files for cover methods and optionally references. The cover method file must include user codes for both cover methods and cover indices. If reference data is provided, it will be uploaded first and the generated vb_rf_codes will be merged into the cover method data before uploading cover methods and cover indices.
         
@@ -249,7 +249,7 @@ class CoverMethod(Operator):
                 }
                 start = time.time()
                 ds = UserDataset(self.params).upload_user_dataset(
-                    dataset_input, conn)
+                    dataset_input, conn, claims=claims)
                 print(ds)
                 end = time.time()
                 print(f"Time to upload dataset: {end - start} seconds")

--- a/src/vegbank/operators/PlantConcept.py
+++ b/src/vegbank/operators/PlantConcept.py
@@ -334,7 +334,7 @@ class PlantConcept(Operator):
 
         return params
 
-    def upload_all(self, request):
+    def upload_all(self, request, claims=None):
         """
         Orchestrate the insertion of client-provided Plant Concept data into
         VegBank, starting with the Flask request containing the uploaded data
@@ -547,7 +547,7 @@ class PlantConcept(Operator):
                 }
                 start = time.time()
                 ds = UserDataset(self.params).upload_user_dataset(
-                    dataset_input, conn)
+                    dataset_input, conn, claims=claims)
                 print(ds)
                 end = time.time()
                 print(f"Time to upload dataset: {end - start} seconds")

--- a/src/vegbank/operators/PlotObservation.py
+++ b/src/vegbank/operators/PlotObservation.py
@@ -691,7 +691,7 @@ class PlotObservation(Operator):
 
         return to_return
 
-    def upload_all(self, request):
+    def upload_all(self, request, claims=None):
         """
         Orchestrate the insertion of client-provided Plot Observation data into
         VegBank, starting with the Flask request containing the uploaded data
@@ -1051,7 +1051,7 @@ class PlotObservation(Operator):
                 }
                 start = time.time()
                 ds = UserDataset(self.params).upload_user_dataset(
-                    dataset_input, conn)
+                    dataset_input, conn, claims=claims)
                 print(ds)
                 end = time.time()
                 print(f"Time to upload dataset: {end - start} seconds")

--- a/src/vegbank/operators/StratumMethod.py
+++ b/src/vegbank/operators/StratumMethod.py
@@ -360,7 +360,7 @@ class StratumMethod(Operator):
 
         return to_return
     
-    def upload_all(self, request):
+    def upload_all(self, request, claims=None):
         '''
         Handles the upload of stratum method data, including associated 
         reference data if provided, and stratum type data. Validates the 
@@ -457,7 +457,7 @@ class StratumMethod(Operator):
                 }
                 start = time.time()
                 ds = UserDataset(self.params).upload_user_dataset(
-                    dataset_input, conn)
+                    dataset_input, conn, claims=claims)
                 print(ds)
                 end = time.time()
                 print(f"Time to upload dataset: {end - start} seconds")

--- a/src/vegbank/operators/TaxonInterpretation.py
+++ b/src/vegbank/operators/TaxonInterpretation.py
@@ -173,7 +173,7 @@ class TaxonInterpretation(Operator):
             'params': []
         }
     
-    def upload_all(self, request):
+    def upload_all(self, request, claims=None):
         """
         Orchestrate the insertion of client-provided Taxon Interpretation data into
         VegBank, starting with the Flask request containing the uploaded data
@@ -322,7 +322,7 @@ class TaxonInterpretation(Operator):
                 }
                 start = time.time()
                 ds = UserDataset(self.params).upload_user_dataset(
-                    dataset_input, conn)
+                    dataset_input, conn, claims=claims)
                 print(ds)
                 end = time.time()
                 print(f"Time to upload dataset: {end - start} seconds")

--- a/src/vegbank/vegbankapi.py
+++ b/src/vegbank/vegbankapi.py
@@ -188,7 +188,7 @@ def plot_observations(vb_code, claims=None):
     """
     plot_observation_operator = PlotObservation(params)
     if request.method == 'POST':
-        return PlotObservation(params).upload_all(request)
+        return PlotObservation(params).upload_all(request, claims=claims)
     elif request.method == 'GET':
         if request.args.get('bundle') is not None:
             return PlotObservationBundle(params).get_vegbank_resources(request, vb_code)
@@ -430,7 +430,7 @@ def taxon_interpretations(vb_code, claims=None):
         to_return = None
         
         try:
-            return taxon_interpretation_operator.upload_all(request)
+            return taxon_interpretation_operator.upload_all(request, claims=claims)
         except Exception as e:
             print(traceback.format_exc())
             return jsonify_error_message(
@@ -492,7 +492,7 @@ def community_classifications(vb_code, claims=None):
     """
     community_classification_operator = CommunityClassification(params)
     if request.method == 'POST':
-        return community_classification_operator.upload_all(request)
+        return community_classification_operator.upload_all(request, claims=claims)
     elif request.method == 'GET':
         return community_classification_operator.get_vegbank_resources(request,
                                                                        vb_code)
@@ -644,7 +644,7 @@ def community_concepts(vb_code, claims=None):
     """
     community_concept_operator = CommunityConcept(params)
     if request.method == 'POST':
-        return community_concept_operator.upload_all(request)
+        return community_concept_operator.upload_all(request, claims=claims)
     elif request.method == 'GET':
         return community_concept_operator.get_vegbank_resources(request, vb_code)
     else:
@@ -736,7 +736,7 @@ def plant_concepts(vb_code, claims=None):
     """
     plant_concept_operator = PlantConcept(params)
     if request.method == 'POST':
-        return plant_concept_operator.upload_all(request)
+        return plant_concept_operator.upload_all(request, claims=claims)
     elif request.method == 'GET':
         return plant_concept_operator.get_vegbank_resources(request, vb_code)
     else:
@@ -896,7 +896,7 @@ def cover_methods(cm_code, claims=None):
     """
     cover_method_operator = CoverMethod(params)
     if request.method == 'POST':
-        return cover_method_operator.upload_all(request)
+        return cover_method_operator.upload_all(request, claims=claims)
     elif request.method == 'GET':
         return cover_method_operator.get_vegbank_resources(request, cm_code)
     else:
@@ -946,7 +946,7 @@ def stratum_methods(sm_code, claims=None):
     """
     stratum_method_operator = StratumMethod(params)
     if request.method == 'POST':
-        return stratum_method_operator.upload_all(request)
+        return stratum_method_operator.upload_all(request, claims=claims)
     elif request.method == 'GET':
         return stratum_method_operator.get_vegbank_resources(request, sm_code)
     else:


### PR DESCRIPTION
### What
This PR fixes a bug where the datasets created automatically by uploads do not have correct usr/party records attached to them. The fix passes the claims information through the upload methods into the upload_user_dataset method, where they are used by the existing process. 

### Why
Datasets are a way we track who uploads what data, and without that information tracking that becomes very hard. 

### How
The upload_user_dataset method already has logic to upsert both party and usr records based on the claims from a user's auth token. We just needed to pass those claims into the method from all the various upload_all methods the same way the user-datasets endpoint was already doing. 